### PR TITLE
feat(CLI): support `init` scripts for contracts in `environments.toml`

### DIFF
--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -52,6 +52,8 @@ heck = "0.5.0"
 pathdiff = "0.2.1"
 sha2 = "0.10.7"
 hex = "0.4.3"
+sha2 = "0.10.7"
+hex = "0.4.3"
 shlex = "1.1.0"
 symlink = "0.1.0"
 toml = { version = "0.8.12", features = ["parse"] }

--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -52,8 +52,6 @@ heck = "0.5.0"
 pathdiff = "0.2.1"
 sha2 = "0.10.7"
 hex = "0.4.3"
-sha2 = "0.10.7"
-hex = "0.4.3"
 shlex = "1.1.0"
 symlink = "0.1.0"
 toml = { version = "0.8.12", features = ["parse"] }

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -3,6 +3,7 @@ use crate::commands::build::env_toml;
 use stellar_xdr::curr::Error as xdrError;
 use serde_json;
 use soroban_cli::commands::NetworkRunnable;
+use soroban_cli::commands::network::Args as Network;
 use soroban_cli::utils::contract_hash;
 use soroban_cli::utils::contract_hash;
 use soroban_cli::{commands as cli, CommandParser};
@@ -13,7 +14,6 @@ use serde_json;
 use std::hash::Hash;
 use stellar_xdr::curr::Error as xdrError;
 
-use super::env_toml::Network;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 pub enum LoamEnv {
@@ -83,7 +83,7 @@ impl Args {
             return Ok(());
         };
 
-        Self::add_network_to_env(&current_env.network)?;
+        Self::add_network_to_env(current_env.network.clone())?;
         Self::handle_accounts(current_env.accounts.as_deref()).await?;
         self.handle_contracts(
             workspace_root,
@@ -105,49 +105,24 @@ impl Args {
     /// We could set `STELLAR_NETWORK` instead, but when importing contracts, we want to hard-code
     /// the network passphrase. So if given a network name, we use soroban-cli to fetch the RPC url
     /// & passphrase for that named network, and still set the environment variables.
-    fn add_network_to_env(network: &env_toml::Network) -> Result<(), Error> {
-        match &network {
-            Network {
-                name: Some(name), ..
-            } => {
-                let cli::network::Network {
-                    rpc_url,
-                    network_passphrase,
-                } = (cli::network::Args {
-                    network: Some(name.clone()),
-                    rpc_url: None,
-                    network_passphrase: None,
-                })
-                .get(&cli::config::locator::Args {
-                    global: false,
-                    config_dir: None,
-                })?;
-                eprintln!("🌐 using {name} network");
-                std::env::set_var("STELLAR_RPC_URL", rpc_url);
-                std::env::set_var("STELLAR_NETWORK_PASSPHRASE", network_passphrase);
-            }
-            Network {
-                rpc_url: Some(rpc_url),
-                network_passphrase: Some(passphrase),
-                ..
-            } => {
-                std::env::set_var("STELLAR_RPC_URL", rpc_url);
-                std::env::set_var("STELLAR_NETWORK_PASSPHRASE", passphrase);
-                eprintln!("🌐 using network at {rpc_url}");
-            }
-            _ => return Err(Error::MalformedNetwork),
+    fn add_network_to_env(network: cli::network::Args) -> Result<(), Error> {
+        let cli::network::Network {
+            rpc_url,
+            network_passphrase,
+        } = network.get(&cli::config::locator::Args {
+            global: false,
+            config_dir: None,
+        })?;
+
+        std::env::set_var("STELLAR_RPC_URL", &rpc_url);
+        std::env::set_var("STELLAR_NETWORK_PASSPHRASE", &network_passphrase);
+
+        match network.network {
+            Some(name) => eprintln!("🌐 using {name} network"),
+            None => eprintln!("🌐 using network at {rpc_url}"),
         }
 
         Ok(())
-    }
-
-
-    fn get_network_args(network: &Network) -> cli::network::Args {
-        cli::network::Args {
-            rpc_url: network.rpc_url.clone(),
-            network_passphrase: network.network_passphrase.clone(),
-            network: network.name.clone(),
-        }
     }
 
     fn get_config_locator() -> cli::config::locator::Args {
@@ -161,7 +136,7 @@ impl Args {
         let account = std::env::var("STELLAR_ACCOUNT")
             .expect("No STELLAR_ACCOUNT environment variable set");
         cli::config::Args {
-            network: Self::get_network_args(network),
+            network: network.clone(),
             locator: Self::get_config_locator(),
             source_account: account,
             hd_path: Some(0),
@@ -180,7 +155,7 @@ impl Args {
             contract_id: contract_id.to_string(),
             out_file: None, 
             locator: Self::get_config_locator(),
-            network: Self::get_network_args(network),
+            network: network.clone(),
         }
             .run_against_rpc_server(None, None)
             .await?;

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -393,29 +393,4 @@ export default new Client.Client({{
         eprintln!("✅ Initialization script for {name:?} completed successfully");
         Ok(())
     }
-
-    /*async fn run_init_script(
-        &self,
-        name: &str,
-        contract_id: &str,
-        init_script: &str,
-    ) -> Result<(), Error> {
-        for line in init_script.lines() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-
-            let mut args = vec!["--id", contract_id, "--"];
-            args.extend(line.split_whitespace());
-
-            eprintln!("  ↳ Executing: soroban contract invoke {}", args.join(" "));
-            let result = cli::contract::invoke::Cmd::parse_arg_vec(&args)?
-                .run_against_rpc_server(None, None)
-                .await?;
-            eprintln!("  ↳ Result: {:?}", result);
-        }
-        eprintln!("✅ Initialization script for {name:?} completed successfully");
-        Ok(())
-    }*/
 }

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -370,8 +370,6 @@ export default new Client.Client({{
             for part in &parts {
                 if let Some(value) = part.strip_prefix("STELLAR_ACCOUNT=") {
                     source_account = Some(value);
-                } else if let Some(value) = part.strip_prefix("SOROBAN_ACCOUNT=") {
-                    source_account = Some(value);
                 } else {
                     command_parts.push(*part);
                 }

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -281,7 +281,6 @@ export default new Client.Client({{
 
                 // Check if we have an alias saved for this contract
                 let alias = Self::get_contract_alias(name)?;
-                let is_new_deployment = alias.is_none();
                 if let Some(contract_id) = alias {
                     match self
                         .contract_hash_matches(&contract_id, &hash, network)
@@ -315,10 +314,9 @@ export default new Client.Client({{
                 // Save the alias for future use
                 Self::save_contract_alias(name, &contract_id, network)?;
 
-                // Run init script if it's a new deployment and we're in development or test environment
-                if is_new_deployment
-                    && (self.loam_env(LoamEnv::Production) == "development"
-                        || self.loam_env(LoamEnv::Production) == "testing")
+                // Run init script if we're in development or test environment
+                if self.loam_env(LoamEnv::Production) == "development"
+                    || self.loam_env(LoamEnv::Production) == "testing"
                 {
                     if let Some(init_script) = &settings.init {
                         eprintln!("🚀 Running initialization script for {name:?}");

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -3,7 +3,6 @@ use crate::commands::build::env_toml;
 use stellar_xdr::curr::Error as xdrError;
 use serde_json;
 use soroban_cli::commands::NetworkRunnable;
-use soroban_cli::commands::network::Args as Network;
 use soroban_cli::utils::contract_hash;
 use soroban_cli::utils::contract_hash;
 use soroban_cli::{commands as cli, CommandParser};
@@ -14,6 +13,7 @@ use serde_json;
 use std::hash::Hash;
 use stellar_xdr::curr::Error as xdrError;
 
+use super::env_toml::Network;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 pub enum LoamEnv {
@@ -83,7 +83,7 @@ impl Args {
             return Ok(());
         };
 
-        Self::add_network_to_env(current_env.network.clone())?;
+        Self::add_network_to_env(&current_env.network)?;
         Self::handle_accounts(current_env.accounts.as_deref()).await?;
         self.handle_contracts(
             workspace_root,
@@ -105,24 +105,49 @@ impl Args {
     /// We could set `STELLAR_NETWORK` instead, but when importing contracts, we want to hard-code
     /// the network passphrase. So if given a network name, we use soroban-cli to fetch the RPC url
     /// & passphrase for that named network, and still set the environment variables.
-    fn add_network_to_env(network: cli::network::Args) -> Result<(), Error> {
-        let cli::network::Network {
-            rpc_url,
-            network_passphrase,
-        } = network.get(&cli::config::locator::Args {
-            global: false,
-            config_dir: None,
-        })?;
-
-        std::env::set_var("STELLAR_RPC_URL", &rpc_url);
-        std::env::set_var("STELLAR_NETWORK_PASSPHRASE", &network_passphrase);
-
-        match network.network {
-            Some(name) => eprintln!("🌐 using {name} network"),
-            None => eprintln!("🌐 using network at {rpc_url}"),
+    fn add_network_to_env(network: &env_toml::Network) -> Result<(), Error> {
+        match &network {
+            Network {
+                name: Some(name), ..
+            } => {
+                let cli::network::Network {
+                    rpc_url,
+                    network_passphrase,
+                } = (cli::network::Args {
+                    network: Some(name.clone()),
+                    rpc_url: None,
+                    network_passphrase: None,
+                })
+                .get(&cli::config::locator::Args {
+                    global: false,
+                    config_dir: None,
+                })?;
+                eprintln!("🌐 using {name} network");
+                std::env::set_var("STELLAR_RPC_URL", rpc_url);
+                std::env::set_var("STELLAR_NETWORK_PASSPHRASE", network_passphrase);
+            }
+            Network {
+                rpc_url: Some(rpc_url),
+                network_passphrase: Some(passphrase),
+                ..
+            } => {
+                std::env::set_var("STELLAR_RPC_URL", rpc_url);
+                std::env::set_var("STELLAR_NETWORK_PASSPHRASE", passphrase);
+                eprintln!("🌐 using network at {rpc_url}");
+            }
+            _ => return Err(Error::MalformedNetwork),
         }
 
         Ok(())
+    }
+
+
+    fn get_network_args(network: &Network) -> cli::network::Args {
+        cli::network::Args {
+            rpc_url: network.rpc_url.clone(),
+            network_passphrase: network.network_passphrase.clone(),
+            network: network.name.clone(),
+        }
     }
 
     fn get_config_locator() -> cli::config::locator::Args {
@@ -136,7 +161,7 @@ impl Args {
         let account = std::env::var("STELLAR_ACCOUNT")
             .expect("No STELLAR_ACCOUNT environment variable set");
         cli::config::Args {
-            network: network.clone(),
+            network: Self::get_network_args(network),
             locator: Self::get_config_locator(),
             source_account: account,
             hd_path: Some(0),
@@ -155,7 +180,7 @@ impl Args {
             contract_id: contract_id.to_string(),
             out_file: None, 
             locator: Self::get_config_locator(),
-            network: network.clone(),
+            network: Self::get_network_args(network),
         }
             .run_against_rpc_server(None, None)
             .await?;

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -219,15 +219,15 @@ impl Args {
             .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
         let template = format!(
             r#"import * as Client from '{name}';
-    import {{ rpcUrl }} from './util';
+import {{ rpcUrl }} from './util';
     
-    export default new Client.Client({{
-      networkPassphrase: '{network}',
-      contractId: '{contract_id}',
-      rpcUrl,{allow_http}
-      publicKey: undefined,
-    }});
-    "#
+export default new Client.Client({{
+  networkPassphrase: '{network}',
+  contractId: '{contract_id}',
+  rpcUrl,{allow_http}
+  publicKey: undefined,
+}});
+"#
         );
         let path = workspace_root.join(format!("src/contracts/{name}.ts"));
         std::fs::write(path, template)?;

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::struct_excessive_bools)]
 use crate::commands::build::env_toml;
+use stellar_xdr::curr::Error as xdrError;
 use serde_json;
 use soroban_cli::commands::NetworkRunnable;
+use soroban_cli::utils::contract_hash;
 use soroban_cli::utils::contract_hash;
 use soroban_cli::{commands as cli, CommandParser};
 use std::collections::BTreeMap as Map;
 use std::fmt::Debug;
+use std::hash::Hash;
+use serde_json;
 use std::hash::Hash;
 use stellar_xdr::curr::Error as xdrError;
 
@@ -134,67 +138,83 @@ impl Args {
 
         Ok(())
     }
+     
+    fn get_contract_alias(&self, name: &str) -> Result<Option<String>, Error> {
+        let config_dir = cli::config::locator::Args {
+            global: false,
+            config_dir: None,
+        }.config_dir()?;
+        let alias_file = config_dir.join("contract-ids").join(format!("{}.json", name));
+        
+        if alias_file.exists() {
+            let content = std::fs::read_to_string(alias_file)?;
+            let alias_data: serde_json::Value = serde_json::from_str(&content)?;
+            let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
+                .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
+            
+            if let Some(id) = alias_data["ids"].get(&network_passphrase) {
+                Ok(Some(id.as_str().unwrap().to_string()))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
 
-    fn get_network_args(network: &Network) -> cli::network::Args {
-        cli::network::Args {
+    async fn contract_hash_matches(&self, contract_id: &str, hash: &str, network: &Network) -> Result<bool, Error> {
+        let network_args = cli::network::Args {
             rpc_url: network.rpc_url.clone(),
             network_passphrase: network.network_passphrase.clone(),
             network: network.name.clone(),
-        }
-    }
-
-    fn get_config_locator() -> cli::config::locator::Args {
-        cli::config::locator::Args {
+        };
+        let config_dir = cli::config::locator::Args {
             global: false,
             config_dir: None,
-        }
-    }
-
-    fn get_contract_alias(name: &str) -> Result<Option<String>, cli::config::locator::Error> {
-        let config_dir = Self::get_config_locator();
-        let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
-            .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
-        config_dir.get_contract_id(name, &network_passphrase)
-    }
-
-    async fn contract_hash_matches(
-        &self,
-        contract_id: &str,
-        hash: &str,
-        network: &Network,
-    ) -> Result<bool, Error> {
+        };
         let hash_vec = cli::contract::fetch::Cmd {
             contract_id: contract_id.to_string(),
-            out_file: None,
-            locator: Self::get_config_locator(),
-            network: Self::get_network_args(network),
+            out_file: None, 
+            locator: config_dir,
+            network: network_args,
         }
-        .run_against_rpc_server(None, None)
-        .await?;
+            .run_against_rpc_server(None, None)
+            .await?;
         let ctrct_hash = contract_hash(&hash_vec)?;
-        Ok(hex::encode(ctrct_hash) == hash)
+        let c_hash_string = hex::encode(ctrct_hash).to_string();
+        Ok(c_hash_string == hash)
     }
 
-    fn save_contract_alias(
-        name: &str,
-        contract_id: &str,
-        network: &Network,
-    ) -> Result<(), cli::config::locator::Error> {
-        let config_dir = Self::get_config_locator();
-        let passphrase = network
-            .network_passphrase
-            .clone()
-            .expect("You must set the network passphrase");
-        config_dir.save_contract_id(&passphrase, contract_id, name)
+    fn save_contract_alias(&self, name: &str, contract_id: &str) -> Result<(), Error> {
+        let config_dir = cli::config::locator::Args {
+            global: false,
+            config_dir: None,
+        }.config_dir()?;
+        let alias_dir = config_dir.join("contract-ids");
+        std::fs::create_dir_all(&alias_dir)?;
+        println!("{}", alias_dir.to_str().unwrap());
+        
+        let alias_file = alias_dir.join(format!("{}.json", name));
+        let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
+            .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
+        
+        let mut alias_data = if alias_file.exists() {
+            let content = std::fs::read_to_string(&alias_file)?;
+            serde_json::from_str(&content)?
+        } else {
+            serde_json::json!({ "ids": {} })
+        };
+    
+        alias_data["ids"][&network_passphrase] = serde_json::Value::String(contract_id.to_string());
+        
+        let content = serde_json::to_string_pretty(&alias_data)?;
+        std::fs::write(alias_file, content)?;
+        
+        Ok(())
     }
 
-    fn write_contract_template(
-        self,
-        workspace_root: &std::path::Path,
-        name: &str,
-        contract_id: &str,
-    ) -> Result<(), Error> {
-        let allow_http = if self.loam_env(LoamEnv::Production) == "development" {
+    fn write_contract_template(&self, workspace_root: &std::path::Path, name: &str, contract_id: &str) -> Result<(), Error> {
+        let allow_http = if self.loam_env() == "development" {
             "\n  allowHttp: true,"
         } else {
             ""
@@ -203,15 +223,15 @@ impl Args {
             .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
         let template = format!(
             r#"import * as Client from '{name}';
-import {{ rpcUrl }} from './util';
+    import {{ rpcUrl }} from './util';
     
-export default new Client.Client({{
-  networkPassphrase: '{network}',
-  contractId: '{contract_id}',
-  rpcUrl,{allow_http}
-  publicKey: undefined,
-}});
-"#
+    export default new Client.Client({{
+      networkPassphrase: '{network}',
+      contractId: '{contract_id}',
+      rpcUrl,{allow_http}
+      publicKey: undefined,
+    }});
+    "#
         );
         let path = workspace_root.join(format!("src/contracts/{name}.ts"));
         std::fs::write(path, template)?;
@@ -254,6 +274,8 @@ export default new Client.Client({{
         contracts: Option<&Map<Box<str>, env_toml::Contract>>,
         network: &Network,
     ) -> Result<(), Error> {
+        println!("Workspace root: {:?}", workspace_root);
+        println!("Contracts: {:?}", contracts);
         let Some(contracts) = contracts else {
             return Ok(());
         };
@@ -333,4 +355,5 @@ export default new Client.Client({{
 
         Ok(())
     }
+
 }

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -1,15 +1,11 @@
 #![allow(clippy::struct_excessive_bools)]
 use crate::commands::build::env_toml;
-use stellar_xdr::curr::Error as xdrError;
 use serde_json;
 use soroban_cli::commands::NetworkRunnable;
-use soroban_cli::utils::contract_hash;
 use soroban_cli::utils::contract_hash;
 use soroban_cli::{commands as cli, CommandParser};
 use std::collections::BTreeMap as Map;
 use std::fmt::Debug;
-use std::hash::Hash;
-use serde_json;
 use std::hash::Hash;
 use stellar_xdr::curr::Error as xdrError;
 
@@ -63,8 +59,6 @@ pub enum Error {
     ContractFetch(#[from] cli::contract::fetch::Error),
     #[error(transparent)]
     ConfigLocator(#[from] cli::config::locator::Error),
-    #[error(transparent)]
-    ConfigAlias(#[from] cli::config::alias::Error),
     #[error(transparent)]
     ContractInvoke(#[from] cli::contract::invoke::Error),
     #[error(transparent)]
@@ -158,22 +152,8 @@ impl Args {
         }
     }
 
-    fn get_config_dir(network: &Network) -> cli::config::Args {
-        let account =
-            std::env::var("STELLAR_ACCOUNT").expect("No STELLAR_ACCOUNT environment variable set");
-        cli::config::Args {
-            network: Self::get_network_args(network),
-            locator: Self::get_config_locator(),
-            source_account: account,
-            hd_path: Some(0),
-        }
-    }
-
-    fn get_contract_alias(
-        name: &str,
-        network: &Network,
-    ) -> Result<Option<String>, cli::config::alias::Error> {
-        let config_dir = Self::get_config_dir(network);
+    fn get_contract_alias(name: &str) -> Result<Option<String>, cli::config::locator::Error> {
+        let config_dir = Self::get_config_locator();
         let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
             .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
         config_dir.get_contract_id(name, &network_passphrase)
@@ -201,9 +181,13 @@ impl Args {
         name: &str,
         contract_id: &str,
         network: &Network,
-    ) -> Result<(), cli::config::alias::Error> {
-        let config_dir = Self::get_config_dir(network);
-        config_dir.save_contract_id(contract_id, name)
+    ) -> Result<(), cli::config::locator::Error> {
+        let config_dir = Self::get_config_locator();
+        let passphrase = network
+            .network_passphrase
+            .clone()
+            .expect("You must set a network passphrase.");
+        config_dir.save_contract_id(&passphrase, contract_id, name)
     }
 
     fn write_contract_template(
@@ -212,7 +196,7 @@ impl Args {
         name: &str,
         contract_id: &str,
     ) -> Result<(), Error> {
-        let allow_http = if self.loam_env() == "development" {
+        let allow_http = if self.loam_env(LoamEnv::Production) == "development" {
             "\n  allowHttp: true,"
         } else {
             ""
@@ -296,7 +280,7 @@ export default new Client.Client({{
                 eprintln!("    ↳ hash: {hash}");
 
                 // Check if we have an alias saved for this contract
-                let alias = Self::get_contract_alias(name, network)?;
+                let alias = Self::get_contract_alias(name)?;
                 let is_new_deployment = alias.is_none();
                 if let Some(contract_id) = alias {
                     match self
@@ -307,7 +291,7 @@ export default new Client.Client({{
                             eprintln!("✅ Contract {name:?} is up to date");
                             continue;
                         }
-                        Ok(false) if self.loam_env() == "production" => {
+                        Ok(false) if self.loam_env(LoamEnv::Production) == "production" => {
                             return Err(Error::ContractUpdateNotAllowed(name.to_string()));
                         }
                         Ok(false) => eprintln!("🔄 Updating contract {name:?}"),
@@ -332,10 +316,14 @@ export default new Client.Client({{
                 Self::save_contract_alias(name, &contract_id, network)?;
 
                 // Run init script if it's a new deployment and we're in development or test environment
-                if is_new_deployment && (self.loam_env() == "development" || self.loam_env() == "test") {
+                if is_new_deployment
+                    && (self.loam_env(LoamEnv::Production) == "development"
+                        || self.loam_env(LoamEnv::Production) == "test")
+                {
                     if let Some(init_script) = &settings.init {
                         eprintln!("🚀 Running initialization script for {name:?}");
-                        self.run_init_script(name, &contract_id, init_script).await?;
+                        self.run_init_script(name, &contract_id, init_script)
+                            .await?;
                     }
                 }
 
@@ -361,7 +349,12 @@ export default new Client.Client({{
         Ok(())
     }
 
-    async fn run_init_script(&self, name: &str, contract_id: &str, init_script: &str) -> Result<(), Error> {
+    async fn run_init_script(
+        &self,
+        name: &str,
+        contract_id: &str,
+        init_script: &str,
+    ) -> Result<(), Error> {
         for line in init_script.lines() {
             let line = line.trim();
             if line.is_empty() {

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -64,6 +64,8 @@ pub enum Error {
     #[error(transparent)]
     ConfigLocator(#[from] cli::config::locator::Error),
     #[error(transparent)]
+    ConfigAlias(#[from] cli::config::alias::Error),
+    #[error(transparent)]
     Clap(#[from] clap::Error),
     #[error(transparent)]
     WasmHash(#[from] xdrError),
@@ -138,79 +140,57 @@ impl Args {
 
         Ok(())
     }
-     
-    fn get_contract_alias(&self, name: &str) -> Result<Option<String>, Error> {
-        let config_dir = cli::config::locator::Args {
-            global: false,
-            config_dir: None,
-        }.config_dir()?;
-        let alias_file = config_dir.join("contract-ids").join(format!("{}.json", name));
-        
-        if alias_file.exists() {
-            let content = std::fs::read_to_string(alias_file)?;
-            let alias_data: serde_json::Value = serde_json::from_str(&content)?;
-            let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
-                .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
-            
-            if let Some(id) = alias_data["ids"].get(&network_passphrase) {
-                Ok(Some(id.as_str().unwrap().to_string()))
-            } else {
-                Ok(None)
-            }
-        } else {
-            Ok(None)
-        }
-    }
 
-    async fn contract_hash_matches(&self, contract_id: &str, hash: &str, network: &Network) -> Result<bool, Error> {
-        let network_args = cli::network::Args {
+
+    fn get_network_args(network: &Network) -> cli::network::Args {
+        cli::network::Args {
             rpc_url: network.rpc_url.clone(),
             network_passphrase: network.network_passphrase.clone(),
             network: network.name.clone(),
-        };
-        let config_dir = cli::config::locator::Args {
+        }
+    }
+
+    fn get_config_locator() -> cli::config::locator::Args {
+        cli::config::locator::Args {
             global: false,
             config_dir: None,
-        };
+        }
+    }
+
+    fn get_config_dir(network: &Network) -> cli::config::Args {
+        let account = std::env::var("STELLAR_ACCOUNT")
+            .expect("No STELLAR_ACCOUNT environment variable set");
+        cli::config::Args {
+            network: Self::get_network_args(network),
+            locator: Self::get_config_locator(),
+            source_account: account,
+            hd_path: Some(0),
+        }
+    }
+     
+    fn get_contract_alias(&self, name: &str, network: &Network) -> Result<Option<String>, cli::config::alias::Error> {
+        let config_dir = Self::get_config_dir(network);
+        let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
+            .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
+        config_dir.get_contract_id(name, &network_passphrase)
+    }
+
+    async fn contract_hash_matches(&self, contract_id: &str, hash: &str, network: &Network) -> Result<bool, Error> {
         let hash_vec = cli::contract::fetch::Cmd {
             contract_id: contract_id.to_string(),
             out_file: None, 
-            locator: config_dir,
-            network: network_args,
+            locator: Self::get_config_locator(),
+            network: Self::get_network_args(network),
         }
             .run_against_rpc_server(None, None)
             .await?;
         let ctrct_hash = contract_hash(&hash_vec)?;
-        let c_hash_string = hex::encode(ctrct_hash).to_string();
-        Ok(c_hash_string == hash)
+        Ok(hex::encode(ctrct_hash) == hash)
     }
 
-    fn save_contract_alias(&self, name: &str, contract_id: &str) -> Result<(), Error> {
-        let config_dir = cli::config::locator::Args {
-            global: false,
-            config_dir: None,
-        }.config_dir()?;
-        let alias_dir = config_dir.join("contract-ids");
-        std::fs::create_dir_all(&alias_dir)?;
-        println!("{}", alias_dir.to_str().unwrap());
-        
-        let alias_file = alias_dir.join(format!("{}.json", name));
-        let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
-            .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
-        
-        let mut alias_data = if alias_file.exists() {
-            let content = std::fs::read_to_string(&alias_file)?;
-            serde_json::from_str(&content)?
-        } else {
-            serde_json::json!({ "ids": {} })
-        };
-    
-        alias_data["ids"][&network_passphrase] = serde_json::Value::String(contract_id.to_string());
-        
-        let content = serde_json::to_string_pretty(&alias_data)?;
-        std::fs::write(alias_file, content)?;
-        
-        Ok(())
+    fn save_contract_alias(&self, name: &str, contract_id: &str, network: &Network) -> Result<(), cli::config::alias::Error> {
+        let config_dir = Self::get_config_dir(network);
+        config_dir.save_contract_id(contract_id, name)
     }
 
     fn write_contract_template(&self, workspace_root: &std::path::Path, name: &str, contract_id: &str) -> Result<(), Error> {
@@ -274,8 +254,6 @@ impl Args {
         contracts: Option<&Map<Box<str>, env_toml::Contract>>,
         network: &Network,
     ) -> Result<(), Error> {
-        println!("Workspace root: {:?}", workspace_root);
-        println!("Contracts: {:?}", contracts);
         let Some(contracts) = contracts else {
             return Ok(());
         };
@@ -300,19 +278,16 @@ impl Args {
                 eprintln!("    ↳ hash: {hash}");
 
                 // Check if we have an alias saved for this contract
-                let alias = Self::get_contract_alias(name)?;
+                let alias = self.get_contract_alias(&name, &network)?;
                 if let Some(contract_id) = alias {
-                    match self
-                        .contract_hash_matches(&contract_id, &hash, network)
-                        .await
-                    {
+                    match self.contract_hash_matches(&contract_id, &hash, &network).await {
                         Ok(true) => {
                             eprintln!("✅ Contract {name:?} is up to date");
                             continue;
-                        }
-                        Ok(false) if self.loam_env(LoamEnv::Production) == "production" => {
+                        },
+                        Ok(false) if self.loam_env() == "production" => {
                             return Err(Error::ContractUpdateNotAllowed(name.to_string()));
-                        }
+                        },
                         Ok(false) => eprintln!("🔄 Updating contract {name:?}"),
                         Err(e) => return Err(e),
                     }
@@ -332,7 +307,7 @@ impl Args {
                 eprintln!("    ↳ contract_id: {contract_id}");
 
                 // Save the alias for future use
-                Self::save_contract_alias(name, &contract_id, network)?;
+                self.save_contract_alias(&name, &contract_id, &network)?;
 
                 eprintln!("🎭 binding {name:?} contract");
                 cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[

--- a/crates/loam-cli/src/commands/build/env_toml.rs
+++ b/crates/loam-cli/src/commands/build/env_toml.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap as Map;
 use std::io;
 use std::path::Path;
-use soroban_cli::commands::network::Args as Network;
-use serde::Deserialize;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -14,47 +12,20 @@ pub enum Error {
 
 type Environments = Map<Box<str>, Environment>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, serde::Deserialize, Clone)]
 pub struct Environment {
     pub accounts: Option<Vec<Account>>,
     pub network: Network,
     pub contracts: Option<Map<Box<str>, Contract>>,
 }
 
-impl<'de> Deserialize<'de> for Environment {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Helper {
-            accounts: Option<Vec<Account>>,
-            network: NetworkHelper,
-            contracts: Option<Map<Box<str>, Contract>>,
-        }
-
-        #[derive(Deserialize)]
-        struct NetworkHelper {
-            rpc_url: Option<String>,
-            network_passphrase: Option<String>,
-            network: Option<String>,
-        }
-
-        let helper = Helper::deserialize(deserializer)?;
-        
-        let network = Network {
-            rpc_url: helper.network.rpc_url,
-            network_passphrase: helper.network.network_passphrase,
-            network: helper.network.network,
-            ..Default::default() // This will set any other fields to their default values
-        };
-
-        Ok(Environment {
-            accounts: helper.accounts,
-            network,
-            contracts: helper.contracts,
-        })
-    }
+#[derive(Debug, serde::Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct Network {
+    pub name: Option<String>,
+    pub rpc_url: Option<String>,
+    pub network_passphrase: Option<String>,
+    // run_locally: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize, Clone)]

--- a/crates/loam-cli/src/commands/build/env_toml.rs
+++ b/crates/loam-cli/src/commands/build/env_toml.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap as Map;
 use std::io;
 use std::path::Path;
+use soroban_cli::commands::network::Args as Network;
+use serde::Deserialize;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -12,20 +14,47 @@ pub enum Error {
 
 type Environments = Map<Box<str>, Environment>;
 
-#[derive(Debug, serde::Deserialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct Environment {
     pub accounts: Option<Vec<Account>>,
     pub network: Network,
     pub contracts: Option<Map<Box<str>, Contract>>,
 }
 
-#[derive(Debug, serde::Deserialize, Clone)]
-#[serde(rename_all = "kebab-case")]
-pub struct Network {
-    pub name: Option<String>,
-    pub rpc_url: Option<String>,
-    pub network_passphrase: Option<String>,
-    // run_locally: Option<bool>,
+impl<'de> Deserialize<'de> for Environment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            accounts: Option<Vec<Account>>,
+            network: NetworkHelper,
+            contracts: Option<Map<Box<str>, Contract>>,
+        }
+
+        #[derive(Deserialize)]
+        struct NetworkHelper {
+            rpc_url: Option<String>,
+            network_passphrase: Option<String>,
+            network: Option<String>,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        
+        let network = Network {
+            rpc_url: helper.network.rpc_url,
+            network_passphrase: helper.network.network_passphrase,
+            network: helper.network.network,
+            ..Default::default() // This will set any other fields to their default values
+        };
+
+        Ok(Environment {
+            accounts: helper.accounts,
+            network,
+            contracts: helper.contracts,
+        })
+    }
 }
 
 #[derive(Debug, serde::Deserialize, Clone)]

--- a/crates/loam-cli/src/commands/build/env_toml.rs
+++ b/crates/loam-cli/src/commands/build/env_toml.rs
@@ -39,6 +39,9 @@ pub struct Account {
 pub struct Contract {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub workspace: bool,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub init: Option<String>,
 }
 
 impl Environment {

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/Cargo.lock
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/Cargo.lock
@@ -1129,6 +1129,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-token-contract"
+version = "0.0.6"
+dependencies = [
+ "soroban-sdk",
+ "soroban-token-sdk",
+]
+
+[[package]]
+name = "soroban-token-sdk"
+version = "20.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8ed0ae2e5d5e67b7939200bba3712b4c81dcf87b2ccd68bba049bec64c780f"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-wasmi"
 version = "0.31.1-soroban.20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/Cargo.toml
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "soroban-token-contract"
+description = "Soroban standard token contract"
+version = "0.0.6"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "20.3.1" }
+soroban-token-sdk = { version = "20.3.1" }
+
+[dev-dependencies]
+soroban-sdk = { version = "20.3.1", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/admin.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/admin.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::{Address, Env};
+
+use crate::storage_types::DataKey;
+
+pub fn has_administrator(e: &Env) -> bool {
+    let key = DataKey::Admin;
+    e.storage().instance().has(&key)
+}
+
+pub fn read_administrator(e: &Env) -> Address {
+    let key = DataKey::Admin;
+    e.storage().instance().get(&key).unwrap()
+}
+
+pub fn write_administrator(e: &Env, id: &Address) {
+    let key = DataKey::Admin;
+    e.storage().instance().set(&key, id);
+}

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/allowance.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/allowance.rs
@@ -1,0 +1,65 @@
+use crate::storage_types::{AllowanceDataKey, AllowanceValue, DataKey};
+use soroban_sdk::{Address, Env};
+
+pub fn read_allowance(e: &Env, from: Address, spender: Address) -> AllowanceValue {
+    let key = DataKey::Allowance(AllowanceDataKey { from, spender });
+    if let Some(allowance) = e.storage().temporary().get::<_, AllowanceValue>(&key) {
+        if allowance.expiration_ledger < e.ledger().sequence() {
+            AllowanceValue {
+                amount: 0,
+                expiration_ledger: allowance.expiration_ledger,
+            }
+        } else {
+            allowance
+        }
+    } else {
+        AllowanceValue {
+            amount: 0,
+            expiration_ledger: 0,
+        }
+    }
+}
+
+pub fn write_allowance(
+    e: &Env,
+    from: Address,
+    spender: Address,
+    amount: i128,
+    expiration_ledger: u32,
+) {
+    let allowance = AllowanceValue {
+        amount,
+        expiration_ledger,
+    };
+
+    if amount > 0 && expiration_ledger < e.ledger().sequence() {
+        panic!("expiration_ledger is less than ledger seq when amount > 0")
+    }
+
+    let key = DataKey::Allowance(AllowanceDataKey { from, spender });
+    e.storage().temporary().set(&key.clone(), &allowance);
+
+    if amount > 0 {
+        let live_for = expiration_ledger
+            .checked_sub(e.ledger().sequence())
+            .unwrap();
+
+        e.storage().temporary().extend_ttl(&key, live_for, live_for)
+    }
+}
+
+pub fn spend_allowance(e: &Env, from: Address, spender: Address, amount: i128) {
+    let allowance = read_allowance(e, from.clone(), spender.clone());
+    if allowance.amount < amount {
+        panic!("insufficient allowance");
+    }
+    if amount > 0 {
+        write_allowance(
+            e,
+            from,
+            spender,
+            allowance.amount - amount,
+            allowance.expiration_ledger,
+        );
+    }
+}

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/balance.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/balance.rs
@@ -1,0 +1,35 @@
+use crate::storage_types::{DataKey, BALANCE_BUMP_AMOUNT, BALANCE_LIFETIME_THRESHOLD};
+use soroban_sdk::{Address, Env};
+
+pub fn read_balance(e: &Env, addr: Address) -> i128 {
+    let key = DataKey::Balance(addr);
+    if let Some(balance) = e.storage().persistent().get::<DataKey, i128>(&key) {
+        e.storage()
+            .persistent()
+            .extend_ttl(&key, BALANCE_LIFETIME_THRESHOLD, BALANCE_BUMP_AMOUNT);
+        balance
+    } else {
+        0
+    }
+}
+
+fn write_balance(e: &Env, addr: Address, amount: i128) {
+    let key = DataKey::Balance(addr);
+    e.storage().persistent().set(&key, &amount);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, BALANCE_LIFETIME_THRESHOLD, BALANCE_BUMP_AMOUNT);
+}
+
+pub fn receive_balance(e: &Env, addr: Address, amount: i128) {
+    let balance = read_balance(e, addr.clone());
+    write_balance(e, addr, balance + amount);
+}
+
+pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
+    let balance = read_balance(e, addr.clone());
+    if balance < amount {
+        panic!("insufficient balance");
+    }
+    write_balance(e, addr, balance - amount);
+}

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/contract.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/contract.rs
@@ -1,0 +1,176 @@
+//! This contract demonstrates a sample implementation of the Soroban token
+//! interface.
+use crate::admin::{has_administrator, read_administrator, write_administrator};
+use crate::allowance::{read_allowance, spend_allowance, write_allowance};
+use crate::balance::{read_balance, receive_balance, spend_balance};
+use crate::metadata::{read_decimal, read_name, read_symbol, write_metadata};
+#[cfg(test)]
+use crate::storage_types::{AllowanceDataKey, AllowanceValue, DataKey};
+use crate::storage_types::{INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD};
+use soroban_sdk::token::{self, Interface as _};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_token_sdk::metadata::TokenMetadata;
+use soroban_token_sdk::TokenUtils;
+
+fn check_nonnegative_amount(amount: i128) {
+    if amount < 0 {
+        panic!("negative amount is not allowed: {}", amount)
+    }
+}
+
+#[contract]
+pub struct Token;
+
+#[contractimpl]
+impl Token {
+    pub fn initialize(e: Env, admin: Address, decimal: u32, name: String, symbol: String) {
+        if has_administrator(&e) {
+            panic!("already initialized")
+        }
+        write_administrator(&e, &admin);
+        if decimal > 18 {
+            panic!("Decimal must not be greater than 18");
+        }
+
+        write_metadata(
+            &e,
+            TokenMetadata {
+                decimal,
+                name,
+                symbol,
+            },
+        )
+    }
+
+    pub fn mint(e: Env, to: Address, amount: i128) {
+        check_nonnegative_amount(amount);
+        let admin = read_administrator(&e);
+        admin.require_auth();
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        receive_balance(&e, to.clone(), amount);
+        TokenUtils::new(&e).events().mint(admin, to, amount);
+    }
+
+    pub fn set_admin(e: Env, new_admin: Address) {
+        let admin = read_administrator(&e);
+        admin.require_auth();
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        write_administrator(&e, &new_admin);
+        TokenUtils::new(&e).events().set_admin(admin, new_admin);
+    }
+
+    #[cfg(test)]
+    pub fn get_allowance(e: Env, from: Address, spender: Address) -> Option<AllowanceValue> {
+        let key = DataKey::Allowance(AllowanceDataKey { from, spender });
+        let allowance = e.storage().temporary().get::<_, AllowanceValue>(&key);
+        allowance
+    }
+}
+
+#[contractimpl]
+impl token::Interface for Token {
+    fn allowance(e: Env, from: Address, spender: Address) -> i128 {
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        read_allowance(&e, from, spender).amount
+    }
+
+    fn approve(e: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
+        from.require_auth();
+
+        check_nonnegative_amount(amount);
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        write_allowance(&e, from.clone(), spender.clone(), amount, expiration_ledger);
+        TokenUtils::new(&e)
+            .events()
+            .approve(from, spender, amount, expiration_ledger);
+    }
+
+    fn balance(e: Env, id: Address) -> i128 {
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        read_balance(&e, id)
+    }
+
+    fn transfer(e: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+
+        check_nonnegative_amount(amount);
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        spend_balance(&e, from.clone(), amount);
+        receive_balance(&e, to.clone(), amount);
+        TokenUtils::new(&e).events().transfer(from, to, amount);
+    }
+
+    fn transfer_from(e: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        spender.require_auth();
+
+        check_nonnegative_amount(amount);
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        spend_allowance(&e, from.clone(), spender, amount);
+        spend_balance(&e, from.clone(), amount);
+        receive_balance(&e, to.clone(), amount);
+        TokenUtils::new(&e).events().transfer(from, to, amount)
+    }
+
+    fn burn(e: Env, from: Address, amount: i128) {
+        from.require_auth();
+
+        check_nonnegative_amount(amount);
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        spend_balance(&e, from.clone(), amount);
+        TokenUtils::new(&e).events().burn(from, amount);
+    }
+
+    fn burn_from(e: Env, spender: Address, from: Address, amount: i128) {
+        spender.require_auth();
+
+        check_nonnegative_amount(amount);
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        spend_allowance(&e, from.clone(), spender, amount);
+        spend_balance(&e, from.clone(), amount);
+        TokenUtils::new(&e).events().burn(from, amount)
+    }
+
+    fn decimals(e: Env) -> u32 {
+        read_decimal(&e)
+    }
+
+    fn name(e: Env) -> String {
+        read_name(&e)
+    }
+
+    fn symbol(e: Env) -> String {
+        read_symbol(&e)
+    }
+}

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/lib.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+
+mod admin;
+mod allowance;
+mod balance;
+mod contract;
+mod metadata;
+mod storage_types;
+mod test;
+
+pub use crate::contract::TokenClient;

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/metadata.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/metadata.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::{Env, String};
+use soroban_token_sdk::{metadata::TokenMetadata, TokenUtils};
+
+pub fn read_decimal(e: &Env) -> u32 {
+    let util = TokenUtils::new(e);
+    util.metadata().get_metadata().decimal
+}
+
+pub fn read_name(e: &Env) -> String {
+    let util = TokenUtils::new(e);
+    util.metadata().get_metadata().name
+}
+
+pub fn read_symbol(e: &Env) -> String {
+    let util = TokenUtils::new(e);
+    util.metadata().get_metadata().symbol
+}
+
+pub fn write_metadata(e: &Env, metadata: TokenMetadata) {
+    let util = TokenUtils::new(e);
+    util.metadata().set_metadata(&metadata);
+}

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/storage_types.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/storage_types.rs
@@ -1,0 +1,30 @@
+use soroban_sdk::{contracttype, Address};
+
+pub(crate) const DAY_IN_LEDGERS: u32 = 17280;
+pub(crate) const INSTANCE_BUMP_AMOUNT: u32 = 7 * DAY_IN_LEDGERS;
+pub(crate) const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
+
+pub(crate) const BALANCE_BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
+pub(crate) const BALANCE_LIFETIME_THRESHOLD: u32 = BALANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
+
+#[derive(Clone)]
+#[contracttype]
+pub struct AllowanceDataKey {
+    pub from: Address,
+    pub spender: Address,
+}
+
+#[contracttype]
+pub struct AllowanceValue {
+    pub amount: i128,
+    pub expiration_ledger: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Allowance(AllowanceDataKey),
+    Balance(Address),
+    State(Address),
+    Admin,
+}

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/test.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/src/test.rs
@@ -1,0 +1,266 @@
+#![cfg(test)]
+extern crate std;
+
+use crate::{contract::Token, TokenClient};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+    Address, Env, IntoVal, Symbol,
+};
+
+fn create_token<'a>(e: &Env, admin: &Address) -> TokenClient<'a> {
+    let token = TokenClient::new(e, &e.register_contract(None, Token {}));
+    token.initialize(admin, &7, &"name".into_val(e), &"symbol".into_val(e));
+    token
+}
+
+#[test]
+fn test() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin1 = Address::generate(&e);
+    let admin2 = Address::generate(&e);
+    let user1 = Address::generate(&e);
+    let user2 = Address::generate(&e);
+    let user3 = Address::generate(&e);
+    let token = create_token(&e, &admin1);
+
+    token.mint(&user1, &1000);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            admin1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("mint"),
+                    (&user1, 1000_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+    assert_eq!(token.balance(&user1), 1000);
+
+    token.approve(&user2, &user3, &500, &200);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user2.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("approve"),
+                    (&user2, &user3, 500_i128, 200_u32).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+    assert_eq!(token.allowance(&user2, &user3), 500);
+
+    token.transfer(&user1, &user2, &600);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("transfer"),
+                    (&user1, &user2, 600_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+    assert_eq!(token.balance(&user1), 400);
+    assert_eq!(token.balance(&user2), 600);
+
+    token.transfer_from(&user3, &user2, &user1, &400);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user3.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    Symbol::new(&e, "transfer_from"),
+                    (&user3, &user2, &user1, 400_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+    assert_eq!(token.balance(&user1), 800);
+    assert_eq!(token.balance(&user2), 200);
+
+    token.transfer(&user1, &user3, &300);
+    assert_eq!(token.balance(&user1), 500);
+    assert_eq!(token.balance(&user3), 300);
+
+    token.set_admin(&admin2);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            admin1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("set_admin"),
+                    (&admin2,).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+
+    // Increase to 500
+    token.approve(&user2, &user3, &500, &200);
+    assert_eq!(token.allowance(&user2, &user3), 500);
+    token.approve(&user2, &user3, &0, &200);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user2.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("approve"),
+                    (&user2, &user3, 0_i128, 200_u32).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+    assert_eq!(token.allowance(&user2, &user3), 0);
+}
+
+#[test]
+fn test_burn() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let user1 = Address::generate(&e);
+    let user2 = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.mint(&user1, &1000);
+    assert_eq!(token.balance(&user1), 1000);
+
+    token.approve(&user1, &user2, &500, &200);
+    assert_eq!(token.allowance(&user1, &user2), 500);
+
+    token.burn_from(&user2, &user1, &500);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user2.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("burn_from"),
+                    (&user2, &user1, 500_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+
+    assert_eq!(token.allowance(&user1, &user2), 0);
+    assert_eq!(token.balance(&user1), 500);
+    assert_eq!(token.balance(&user2), 0);
+
+    token.burn(&user1, &500);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    token.address.clone(),
+                    symbol_short!("burn"),
+                    (&user1, 500_i128).into_val(&e),
+                )),
+                sub_invocations: std::vec![]
+            }
+        )]
+    );
+
+    assert_eq!(token.balance(&user1), 0);
+    assert_eq!(token.balance(&user2), 0);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn transfer_insufficient_balance() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let user1 = Address::generate(&e);
+    let user2 = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.mint(&user1, &1000);
+    assert_eq!(token.balance(&user1), 1000);
+
+    token.transfer(&user1, &user2, &1001);
+}
+
+#[test]
+#[should_panic(expected = "insufficient allowance")]
+fn transfer_from_insufficient_allowance() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let user1 = Address::generate(&e);
+    let user2 = Address::generate(&e);
+    let user3 = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.mint(&user1, &1000);
+    assert_eq!(token.balance(&user1), 1000);
+
+    token.approve(&user1, &user3, &100, &200);
+    assert_eq!(token.allowance(&user1, &user3), 100);
+
+    token.transfer_from(&user3, &user1, &user2, &101);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn initialize_already_initialized() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.initialize(&admin, &10, &"name".into_val(&e), &"symbol".into_val(&e));
+}
+
+#[test]
+#[should_panic(expected = "Decimal must not be greater than 18")]
+fn decimal_is_over_eighteen() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let token = TokenClient::new(&e, &e.register_contract(None, Token {}));
+    token.initialize(&admin, &19, &"name".into_val(&e), &"symbol".into_val(&e));
+}
+
+#[test]
+fn test_zero_allowance() {
+    // Here we test that transfer_from with a 0 amount does not create an empty allowance
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let spender = Address::generate(&e);
+    let from = Address::generate(&e);
+    let token = create_token(&e, &admin);
+
+    token.transfer_from(&spender, &from, &spender, &0);
+    assert!(token.get_allowance(&from, &spender).is_none());
+}

--- a/crates/loam-cli/tests/it/build_clients/init_script.rs
+++ b/crates/loam-cli/tests/it/build_clients/init_script.rs
@@ -1,0 +1,42 @@
+use crate::util::TestEnv;
+
+#[test]
+fn build_command_runs_init() {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        env.set_environments_toml(
+            r#"
+development.accounts = [
+{ name = "alice" },
+{ name = "bob" },
+]
+
+[development.network]
+rpc-url = "http://localhost:8000/rpc"
+network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts.soroban_token_contract]
+workspace = true
+init = """
+STELLAR_ACCOUNT=bob initialize --symbol ABND --decimal 7 --name abundance --admin bob 
+STELLAR_ACCOUNT=bob mint --amount 2000000 --to bob 
+"""
+"#,
+        );
+
+        let output = env
+            .loam_env("development", true)
+            .output()
+            .expect("Failed to execute command");
+
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        // ensure the invoke commands are run with the proper source account
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("--source-account bob -- initialize --symbol ABND --decimal 7 --name abundance --admin bob"));
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("--source-account bob -- mint --amount 2000000 --to bob"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains(
+            "✅ Initialization script for \"soroban_token_contract\" completed successfully"
+        ));
+    })
+}

--- a/crates/loam-cli/tests/it/build_clients/init_script.rs
+++ b/crates/loam-cli/tests/it/build_clients/init_script.rs
@@ -17,12 +17,47 @@ network-passphrase = "Standalone Network ; February 2017"
 [development.contracts.soroban_token_contract]
 workspace = true
 init = """
+initialize --symbol ABND --decimal 7 --name abundance --admin alice
+mint --amount 2000000 --to alice
+"""
+"#,
+        );
+
+        let output = env
+            .loam_env("development", true)
+            .output()
+            .expect("Failed to execute command");
+
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        // ensure the invoke commands are run with the proper source account
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains(" -- initialize --symbol ABND --decimal 7 --name abundance --admin alice"));
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains(" -- mint --amount 2000000 --to alice"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains(
+            "✅ Initialization script for \"soroban_token_contract\" completed successfully"
+        ));
+        // ensure setting STELLAR_ACCOUNT works
+        env.set_environments_toml(
+            r#"
+development.accounts = [
+{ name = "alice" },
+{ name = "bob" },
+]
+
+[development.network]
+rpc-url = "http://localhost:8000/rpc"
+network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts.soroban_token_contract]
+workspace = true
+init = """
 STELLAR_ACCOUNT=bob initialize --symbol ABND --decimal 7 --name abundance --admin bob 
 STELLAR_ACCOUNT=bob mint --amount 2000000 --to bob 
 """
 "#,
         );
-
         let output = env
             .loam_env("development", true)
             .output()

--- a/crates/loam-cli/tests/it/build_clients/mod.rs
+++ b/crates/loam-cli/tests/it/build_clients/mod.rs
@@ -1,6 +1,7 @@
 mod accounts;
 mod contracts;
 mod dev;
+mod init_script;
 mod manifest_path;
 mod network;
 mod no_environments;


### PR DESCRIPTION
Fixes #74 

Runs init scripst which specify invoke commands to be run when first deploying. Checks if there wasn't previously an alias stored to determine when to run the init command. Allows one to specify a source account for the command by prefixing SOROBAN_ACCOUNT=<value> or STELLAR_ACCOUNT=<value>