### PR TITLE
Feature: automatically build clients for all workspaces 

### DIFF
--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -279,7 +279,7 @@ export default new Client.Client({{
                 Some(contracts) => contracts.get(&name as &str),
                 None => None,
             };
-            // Skip only if contract is found and its workspace setting is false
+            // Skip only if contract is found and its `client` setting is false
             if let Some(c) = settings {
                 if !c.client {
                     continue;

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -72,7 +72,11 @@ pub enum Error {
 }
 
 impl Args {
-    pub async fn run(&self, workspace_root: &std::path::Path) -> Result<(), Error> {
+    pub async fn run(
+        &self,
+        workspace_root: &std::path::Path,
+        package_names: Vec<String>,
+    ) -> Result<(), Error> {
         let Some(current_env) =
             env_toml::Environment::get(workspace_root, &self.loam_env(LoamEnv::Production))?
         else {
@@ -84,6 +88,7 @@ impl Args {
         self.handle_contracts(
             workspace_root,
             current_env.contracts.as_ref(),
+            package_names,
             &current_env.network,
         )
         .await?;
@@ -254,94 +259,115 @@ export default new Client.Client({{
         &self,
         workspace_root: &std::path::Path,
         contracts: Option<&Map<Box<str>, env_toml::Contract>>,
+        package_names: Vec<String>,
         network: &Network,
     ) -> Result<(), Error> {
-        let Some(contracts) = contracts else {
+        if package_names.is_empty() {
             return Ok(());
-        };
-        for (name, settings) in contracts {
-            if settings.workspace {
+        }
+        // ensure contract names are valid
+        if let Some(contracts) = contracts {
+            for (name, _) in contracts.iter().filter(|(_, settings)| settings.workspace) {
                 let wasm_path = workspace_root.join(format!("target/loam/{name}.wasm"));
                 if !wasm_path.exists() {
                     return Err(Error::BadContractName(name.to_string()));
                 }
-                eprintln!("📲 installing {name:?} wasm bytecode on-chain...");
-                let hash = cli::contract::install::Cmd::parse_arg_vec(&[
-                    "--wasm",
-                    wasm_path
-                        .to_str()
-                        .expect("we do not support non-utf8 paths"),
-                ])?
-                .run_against_rpc_server(None, None)
-                .await?
-                .into_result()
-                .expect("no hash returned by 'contract install'")
-                .to_string();
-                eprintln!("    ↳ hash: {hash}");
-
-                // Check if we have an alias saved for this contract
-                let alias = Self::get_contract_alias(name)?;
-                if let Some(contract_id) = alias {
-                    match self
-                        .contract_hash_matches(&contract_id, &hash, network)
-                        .await
-                    {
-                        Ok(true) => {
-                            eprintln!("✅ Contract {name:?} is up to date");
-                            continue;
-                        }
-                        Ok(false) if self.loam_env(LoamEnv::Production) == "production" => {
-                            return Err(Error::ContractUpdateNotAllowed(name.to_string()));
-                        }
-                        Ok(false) => eprintln!("🔄 Updating contract {name:?}"),
-                        Err(e) => return Err(e),
-                    }
+            }
+        }
+        for name in package_names {
+            let settings = match contracts {
+                Some(contracts) => contracts.get(&name as &str),
+                None => None,
+            };
+            // Skip only if contract is found and its workspace setting is false
+            if let Some(c) = settings {
+                if !c.workspace {
+                    eprintln!("Skipping {name:?} as its workspace setting is false");
+                    continue;
                 }
+            } else {
+                eprintln!("Contract {name:?} not found in contracts, but continuing anyway");
+            }
+            let wasm_path = workspace_root.join(format!("target/loam/{name}.wasm"));
+            if !wasm_path.exists() {
+                return Err(Error::BadContractName(name.to_string()));
+            }
+            eprintln!("📲 installing {name:?} wasm bytecode on-chain...");
+            let hash = cli::contract::install::Cmd::parse_arg_vec(&[
+                "--wasm",
+                wasm_path
+                    .to_str()
+                    .expect("we do not support non-utf8 paths"),
+            ])?
+            .run_against_rpc_server(None, None)
+            .await?
+            .into_result()
+            .expect("no hash returned by 'contract install'")
+            .to_string();
+            eprintln!("    ↳ hash: {hash}");
 
-                eprintln!("🪞 instantiating {name:?} smart contract");
-                let contract_id = cli::contract::deploy::wasm::Cmd::parse_arg_vec(&[
-                    "--alias",
-                    name,
-                    "--wasm-hash",
-                    &hash,
-                ])?
-                .run_against_rpc_server(None, None)
-                .await?
-                .into_result()
-                .expect("no contract id returned by 'contract deploy'");
-                eprintln!("    ↳ contract_id: {contract_id}");
+            // Check if we have an alias saved for this contract
+            let alias = Self::get_contract_alias(&name)?;
+            if let Some(contract_id) = alias {
+                match self
+                    .contract_hash_matches(&contract_id, &hash, network)
+                    .await
+                {
+                    Ok(true) => {
+                        eprintln!("✅ Contract {name:?} is up to date");
+                        continue;
+                    }
+                    Ok(false) if self.loam_env(LoamEnv::Production) == "production" => {
+                        return Err(Error::ContractUpdateNotAllowed(name.to_string()));
+                    }
+                    Ok(false) => eprintln!("🔄 Updating contract {name:?}"),
+                    Err(e) => return Err(e),
+                }
+            }
 
-                // Save the alias for future use
-                Self::save_contract_alias(name, &contract_id, network)?;
+            eprintln!("🪞 instantiating {name:?} smart contract");
+            let contract_id = cli::contract::deploy::wasm::Cmd::parse_arg_vec(&[
+                "--alias",
+                &name,
+                "--wasm-hash",
+                &hash,
+            ])?
+            .run_against_rpc_server(None, None)
+            .await?
+            .into_result()
+            .expect("no contract id returned by 'contract deploy'");
+            eprintln!("    ↳ contract_id: {contract_id}");
+
+            // Save the alias for future use
+            Self::save_contract_alias(&name, &contract_id, network)?;
 
                 // Run init script if we're in development or test environment
                 if self.loam_env(LoamEnv::Production) == "development"
                     || self.loam_env(LoamEnv::Production) == "testing"
                 {
-                    if let Some(init_script) = &settings.init {
+                    if let Some(init_script) = &settings.unwrap().init {
                         eprintln!("🚀 Running initialization script for {name:?}");
-                        self.run_init_script(name, &contract_id, init_script)
+                        self.run_init_script(&name, &contract_id, init_script)
                             .await?;
                     }
                 }
 
-                eprintln!("🎭 binding {name:?} contract");
-                cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[
-                    "--contract-id",
-                    &contract_id,
-                    "--output-dir",
-                    workspace_root
-                        .join(format!("packages/{name}"))
-                        .to_str()
-                        .expect("we do not support non-utf8 paths"),
-                    "--overwrite",
-                ])?
-                .run()
-                .await?;
+            eprintln!("🎭 binding {name:?} contract");
+            cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[
+                "--contract-id",
+                &contract_id,
+                "--output-dir",
+                workspace_root
+                    .join(format!("packages/{name}"))
+                    .to_str()
+                    .expect("we do not support non-utf8 paths"),
+                "--overwrite",
+            ])?
+            .run()
+            .await?;
 
-                eprintln!("🍽️ importing {:?} contract", name.clone());
-                self.write_contract_template(workspace_root, name, &contract_id)?;
-            };
+            eprintln!("🍽️ importing {:?} contract", name.clone());
+            self.write_contract_template(workspace_root, &name, &contract_id)?;
         }
 
         Ok(())

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -341,16 +341,16 @@ export default new Client.Client({{
             // Save the alias for future use
             Self::save_contract_alias(&name, &contract_id, network)?;
 
-                // Run init script if we're in development or test environment
-                if self.loam_env(LoamEnv::Production) == "development"
-                    || self.loam_env(LoamEnv::Production) == "testing"
-                {
-                    if let Some(init_script) = &settings.unwrap().init {
-                        eprintln!("🚀 Running initialization script for {name:?}");
-                        self.run_init_script(&name, &contract_id, init_script)
-                            .await?;
-                    }
+            // Run init script if we're in development or test environment
+            if self.loam_env(LoamEnv::Production) == "development"
+                || self.loam_env(LoamEnv::Production) == "testing"
+            {
+                if let Some(init_script) = &settings.unwrap().init {
+                    eprintln!("🚀 Running initialization script for {name:?}");
+                    self.run_init_script(&name, &contract_id, init_script)
+                        .await?;
                 }
+            }
 
             eprintln!("🎭 binding {name:?} contract");
             cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -267,7 +267,7 @@ export default new Client.Client({{
         }
         // ensure contract names are valid
         if let Some(contracts) = contracts {
-            for (name, _) in contracts.iter().filter(|(_, settings)| settings.workspace) {
+            for (name, _) in contracts.iter().filter(|(_, settings)| settings.client) {
                 let wasm_path = workspace_root.join(format!("target/loam/{name}.wasm"));
                 if !wasm_path.exists() {
                     return Err(Error::BadContractName(name.to_string()));
@@ -281,7 +281,7 @@ export default new Client.Client({{
             };
             // Skip only if contract is found and its workspace setting is false
             if let Some(c) = settings {
-                if !c.workspace {
+                if !c.client {
                     continue;
                 }
             }

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -282,11 +282,8 @@ export default new Client.Client({{
             // Skip only if contract is found and its workspace setting is false
             if let Some(c) = settings {
                 if !c.workspace {
-                    eprintln!("Skipping {name:?} as its workspace setting is false");
                     continue;
                 }
-            } else {
-                eprintln!("Contract {name:?} not found in contracts, but continuing anyway");
             }
             let wasm_path = workspace_root.join(format!("target/loam/{name}.wasm"));
             if !wasm_path.exists() {
@@ -345,10 +342,12 @@ export default new Client.Client({{
             if self.loam_env(LoamEnv::Production) == "development"
                 || self.loam_env(LoamEnv::Production) == "testing"
             {
-                if let Some(init_script) = &settings.unwrap().init {
-                    eprintln!("🚀 Running initialization script for {name:?}");
-                    self.run_init_script(&name, &contract_id, init_script)
-                        .await?;
+                if let Some(settings) = settings {
+                    if let Some(init_script) = &settings.init {
+                        eprintln!("🚀 Running initialization script for {name:?}");
+                        self.run_init_script(&name, &contract_id, init_script)
+                            .await?;
+                    }
                 }
             }
 

--- a/crates/loam-cli/src/commands/build/env_toml.rs
+++ b/crates/loam-cli/src/commands/build/env_toml.rs
@@ -38,7 +38,7 @@ pub struct Account {
 #[derive(Debug, serde::Deserialize, Clone)]
 pub struct Contract {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub workspace: bool,
+    pub client: bool,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub init: Option<String>,

--- a/crates/loam-cli/src/commands/build/mod.rs
+++ b/crates/loam-cli/src/commands/build/mod.rs
@@ -121,7 +121,9 @@ impl Cmd {
             }
         }
 
+        let mut package_names: Vec<String> = Vec::new();
         for p in packages {
+            package_names.push(p.name.clone().replace('-', "_"));
             let mut cmd = Command::new("cargo");
             cmd.stdout(Stdio::piped());
             cmd.arg("rustc");
@@ -191,7 +193,7 @@ impl Cmd {
 
         if self.build_clients {
             self.build_clients_args
-                .run(&metadata.workspace_root.into_std_path_buf())
+                .run(&metadata.workspace_root.into_std_path_buf(), package_names)
                 .await?;
         }
 

--- a/crates/loam-cli/tests/it/build_clients/accounts.rs
+++ b/crates/loam-cli/tests/it/build_clients/accounts.rs
@@ -10,7 +10,13 @@ network = { rpc-url = "http://localhost:8000/rpc", network-passphrase = "Standal
 accounts = [
     { name = "alice" },
     { name = "bob" },
-]"#);
+]
+[production.contracts]
+hello_world.workspace = false
+soroban_increment_contract.workspace = false
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
+"#);
 
         let stderr = env.loam("build").assert().success().stderr_as_str();
         assert!(stderr.contains("creating keys for \"alice\""));

--- a/crates/loam-cli/tests/it/build_clients/accounts.rs
+++ b/crates/loam-cli/tests/it/build_clients/accounts.rs
@@ -16,6 +16,7 @@ hello_world.workspace = false
 soroban_increment_contract.workspace = false
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#);
 
         let stderr = env.loam("build").assert().success().stderr_as_str();

--- a/crates/loam-cli/tests/it/build_clients/accounts.rs
+++ b/crates/loam-cli/tests/it/build_clients/accounts.rs
@@ -12,11 +12,11 @@ accounts = [
     { name = "bob" },
 ]
 [production.contracts]
-hello_world.workspace = false
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello_world.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#);
 
         let stderr = env.loam("build").assert().success().stderr_as_str();

--- a/crates/loam-cli/tests/it/build_clients/contracts.rs
+++ b/crates/loam-cli/tests/it/build_clients/contracts.rs
@@ -55,7 +55,7 @@ network-passphrase = "Standalone Network ; February 2017"
 }
 
 #[test]
-fn contracts_built_no_workspace() {
+fn contracts_built_by_default() {
     let contracts = [
         "soroban_auth_contract",
         "soroban_custom_types_contract",

--- a/crates/loam-cli/tests/it/build_clients/contracts.rs
+++ b/crates/loam-cli/tests/it/build_clients/contracts.rs
@@ -115,6 +115,7 @@ hello.workspace = true
 soroban_increment_contract.workspace = false
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#,
         );
 
@@ -143,6 +144,7 @@ hello_world.workspace = true
 soroban_increment_contract.workspace = false
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#,
         );
 
@@ -191,9 +193,9 @@ network-passphrase = "Standalone Network ; February 2017"
 
 [production.contracts]
 hello_world.workspace = true
-soroban_increment_contract.workspace = false
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#,
         );
 
@@ -202,6 +204,7 @@ soroban_auth_contract.workspace = false
             .output()
             .expect("Failed to execute command");
 
+        println!("stderr: {}", String::from_utf8_lossy(&output4.stderr));
         // ensure contract hash change check works, should throw error in production
         assert!(!output4.status.success());
         assert!(String::from_utf8_lossy(&output4.stderr)

--- a/crates/loam-cli/tests/it/build_clients/contracts.rs
+++ b/crates/loam-cli/tests/it/build_clients/contracts.rs
@@ -25,7 +25,7 @@ network-passphrase = "Standalone Network ; February 2017"
 "#,
                 contracts
                     .iter()
-                    .map(|c| format!("{c}.workspace = true"))
+                    .map(|c| format!("{c}.client = true"))
                     .collect::<Vec<String>>()
                     .join("\n")
             )
@@ -111,11 +111,11 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [production.contracts]
-hello.workspace = true
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello.client = true
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#,
         );
 
@@ -140,11 +140,11 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [development.contracts]
-hello_world.workspace = true
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello_world.client = true
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#,
         );
 
@@ -192,10 +192,10 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [production.contracts]
-hello_world.workspace = true
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello_world.client = true
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#,
         );
 

--- a/crates/loam-cli/tests/it/build_clients/dev.rs
+++ b/crates/loam-cli/tests/it/build_clients/dev.rs
@@ -55,11 +55,11 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [development.contracts]
-hello_world.workspace = true
-soroban_increment_contract.workspace = true
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello_world.client = true
+soroban_increment_contract.client = true
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#,
             );
 
@@ -88,11 +88,11 @@ rpc-url = "http://localhost:9000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [development.contracts]
-hello_world.workspace = true
-soroban_increment_contract.workspace = true
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello_world.client = true
+soroban_increment_contract.client = true
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#,
             );
 

--- a/crates/loam-cli/tests/it/build_clients/dev.rs
+++ b/crates/loam-cli/tests/it/build_clients/dev.rs
@@ -59,6 +59,7 @@ hello_world.workspace = true
 soroban_increment_contract.workspace = true
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#,
             );
 
@@ -91,6 +92,7 @@ hello_world.workspace = true
 soroban_increment_contract.workspace = true
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#,
             );
 

--- a/crates/loam-cli/tests/it/build_clients/dev.rs
+++ b/crates/loam-cli/tests/it/build_clients/dev.rs
@@ -57,6 +57,8 @@ network-passphrase = "Standalone Network ; February 2017"
 [development.contracts]
 hello_world.workspace = true
 soroban_increment_contract.workspace = true
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
 "#,
             );
 
@@ -87,6 +89,8 @@ network-passphrase = "Standalone Network ; February 2017"
 [development.contracts]
 hello_world.workspace = true
 soroban_increment_contract.workspace = true
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
 "#,
             );
 

--- a/crates/loam-cli/tests/it/build_clients/init_script.rs
+++ b/crates/loam-cli/tests/it/build_clients/init_script.rs
@@ -14,6 +14,12 @@ development.accounts = [
 rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
+[development.contracts]
+hello_world.workspace = false
+soroban_increment_contract.workspace = false
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
+
 [development.contracts.soroban_token_contract]
 workspace = true
 init = """
@@ -49,6 +55,12 @@ development.accounts = [
 [development.network]
 rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts]
+hello_world.workspace = false
+soroban_increment_contract.workspace = false
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
 
 [development.contracts.soroban_token_contract]
 workspace = true

--- a/crates/loam-cli/tests/it/build_clients/init_script.rs
+++ b/crates/loam-cli/tests/it/build_clients/init_script.rs
@@ -15,13 +15,13 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [development.contracts]
-hello_world.workspace = false
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
+hello_world.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
 
 [development.contracts.soroban_token_contract]
-workspace = true
+client = true
 init = """
 initialize --symbol ABND --decimal 7 --name abundance --admin alice
 mint --amount 2000000 --to alice
@@ -57,13 +57,13 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [development.contracts]
-hello_world.workspace = false
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
+hello_world.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
 
 [development.contracts.soroban_token_contract]
-workspace = true
+client = true
 init = """
 STELLAR_ACCOUNT=bob initialize --symbol ABND --decimal 7 --name abundance --admin bob 
 STELLAR_ACCOUNT=bob mint --amount 2000000 --to bob 

--- a/crates/loam-cli/tests/it/build_clients/manifest_path.rs
+++ b/crates/loam-cli/tests/it/build_clients/manifest_path.rs
@@ -18,6 +18,7 @@ hello_world.workspace = false
 soroban_increment_contract.workspace = false
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#,
         );
 

--- a/crates/loam-cli/tests/it/build_clients/manifest_path.rs
+++ b/crates/loam-cli/tests/it/build_clients/manifest_path.rs
@@ -14,11 +14,11 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [production.contracts]
-hello_world.workspace = false
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello_world.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#,
         );
 

--- a/crates/loam-cli/tests/it/build_clients/manifest_path.rs
+++ b/crates/loam-cli/tests/it/build_clients/manifest_path.rs
@@ -12,6 +12,12 @@ production.accounts = [
 [production.network]
 rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
+
+[production.contracts]
+hello_world.workspace = false
+soroban_increment_contract.workspace = false
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
 "#,
         );
 

--- a/crates/loam-cli/tests/it/build_clients/network.rs
+++ b/crates/loam-cli/tests/it/build_clients/network.rs
@@ -12,6 +12,12 @@ production.accounts = [
 [production.network]
 rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
+
+[production.contracts]
+hello_world.workspace = false
+soroban_increment_contract.workspace = false
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
 "#,
         );
 
@@ -43,6 +49,12 @@ production.accounts = [
 ]
 
 production.network.name = "lol"
+
+[production.contracts]
+hello_world.workspace = false
+soroban_increment_contract.workspace = false
+soroban_custom_types_contract.workspace = false
+soroban_auth_contract.workspace = false
 "#,
         );
 

--- a/crates/loam-cli/tests/it/build_clients/network.rs
+++ b/crates/loam-cli/tests/it/build_clients/network.rs
@@ -14,10 +14,10 @@ rpc-url = "http://localhost:8000/rpc"
 network-passphrase = "Standalone Network ; February 2017"
 
 [production.contracts]
-hello_world.workspace = false
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
+hello_world.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
 "#,
         );
 
@@ -51,11 +51,11 @@ production.accounts = [
 production.network.name = "lol"
 
 [production.contracts]
-hello_world.workspace = false
-soroban_increment_contract.workspace = false
-soroban_custom_types_contract.workspace = false
-soroban_auth_contract.workspace = false
-soroban_token_contract.workspace = false
+hello_world.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
 "#,
         );
 

--- a/crates/loam-cli/tests/it/build_clients/network.rs
+++ b/crates/loam-cli/tests/it/build_clients/network.rs
@@ -55,6 +55,7 @@ hello_world.workspace = false
 soroban_increment_contract.workspace = false
 soroban_custom_types_contract.workspace = false
 soroban_auth_contract.workspace = false
+soroban_token_contract.workspace = false
 "#,
         );
 


### PR DESCRIPTION
Addresses https://github.com/loambuild/loam/issues/75

Note I went with the option of just automatically building them. We could always add an option to toggle this pretty easily if needed. It will still check the names of contracts to ensure there aren't any typos but it uses the package name for the main loop.