### PR TITLE
Fix/no account overwrite

### DIFF
--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -227,9 +227,12 @@ export default new Client.Client({{
 
     async fn account_exists(account_name: &str) -> Result<bool, Error> {
         // TODO: this is a workaround until generate is changed to not overwrite accounts
-        match cli::keys::fund::Cmd::parse_arg_vec(&[account_name])?.run().await {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false)
+        match cli::keys::fund::Cmd::parse_arg_vec(&[account_name])?
+            .run()
+            .await
+        {
+            Ok(()) => Ok(true),
+            Err(_) => Ok(false),
         }
     }
 
@@ -253,8 +256,10 @@ export default new Client.Client({{
 
         for account in accounts {
             if Self::account_exists(&account.name).await? {
-                eprintln!("ℹ️ account {:?} already exists, skipping key creation", account.name);
-
+                eprintln!(
+                    "ℹ️ account {:?} already exists, skipping key creation",
+                    account.name
+                );
             } else {
                 eprintln!("🔐 creating keys for {:?}", account.name);
                 cli::keys::generate::Cmd::parse_arg_vec(&[&account.name])?

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -227,13 +227,7 @@ export default new Client.Client({{
 
     async fn account_exists(account_name: &str) -> Result<bool, Error> {
         // TODO: this is a workaround until generate is changed to not overwrite accounts
-        match cli::keys::fund::Cmd::parse_arg_vec(&[account_name])?
-            .run()
-            .await
-        {
-            Ok(()) => Ok(true),
-            Err(_) => Ok(false),
-        }
+        Ok(cli::keys::fund::Cmd::parse_arg_vec(&[account_name])?.run().await.is_ok())
     }
 
     async fn handle_accounts(accounts: Option<&[env_toml::Account]>) -> Result<(), Error> {

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -225,6 +225,14 @@ export default new Client.Client({{
         Ok(())
     }
 
+    async fn account_exists(account_name: &str) -> Result<bool, Error> {
+        // TODO: this is a workaround until generate is changed to not overwrite accounts
+        match cli::keys::fund::Cmd::parse_arg_vec(&[account_name])?.run().await {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false)
+        }
+    }
+
     async fn handle_accounts(accounts: Option<&[env_toml::Account]>) -> Result<(), Error> {
         let Some(accounts) = accounts else {
             return Err(Error::NeedAtLeastOneAccount);
@@ -244,10 +252,15 @@ export default new Client.Client({{
         };
 
         for account in accounts {
-            eprintln!("🔐 creating keys for {:?}", account.name);
-            cli::keys::generate::Cmd::parse_arg_vec(&[&account.name])?
-                .run()
-                .await?;
+            if Self::account_exists(&account.name).await? {
+                eprintln!("ℹ️ account {:?} already exists, skipping key creation", account.name);
+
+            } else {
+                eprintln!("🔐 creating keys for {:?}", account.name);
+                cli::keys::generate::Cmd::parse_arg_vec(&[&account.name])?
+                    .run()
+                    .await?;
+            }
         }
 
         std::env::set_var("STELLAR_ACCOUNT", &default_account);

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -227,7 +227,10 @@ export default new Client.Client({{
 
     async fn account_exists(account_name: &str) -> Result<bool, Error> {
         // TODO: this is a workaround until generate is changed to not overwrite accounts
-        Ok(cli::keys::fund::Cmd::parse_arg_vec(&[account_name])?.run().await.is_ok())
+        Ok(cli::keys::fund::Cmd::parse_arg_vec(&[account_name])?
+            .run()
+            .await
+            .is_ok())
     }
 
     async fn handle_accounts(accounts: Option<&[env_toml::Account]>) -> Result<(), Error> {

--- a/crates/loam-cli/tests/it/build_clients/accounts.rs
+++ b/crates/loam-cli/tests/it/build_clients/accounts.rs
@@ -25,6 +25,11 @@ soroban_token_contract.client = false
         assert!(env.cwd.join(".soroban/identity/alice.toml").exists());
         assert!(env.cwd.join(".soroban/identity/bob.toml").exists());
 
+        // check that they dont get overwritten if build is run again
+        let stderr = env.loam("build").assert().success().stderr_as_str();
+        assert!(stderr.contains("account \"alice\" already exists"));
+        assert!(stderr.contains("account \"bob\" already exists"));
+
         // check that they're actually funded
         let stderr = env
             .soroban("keys")


### PR DESCRIPTION
Temporary workaround while we wait for this to be fixed and released: https://github.com/stellar/stellar-cli/issues/1380

This makes it so that `generate` will not be run if the account already exists. I used `keys fund` because its the only command under `keys` that actually hits the network. Presumably if one is testing on a local instance of stellar then their local identity files might be out of date so using `fund` is the only way to guarantee they actually exist on the network that I'm aware of. If there is a better command to query the network for the existence of the key let me know and I will use that.