### PR TITLE
Fix/support init scripts with quotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,6 +2655,7 @@ dependencies = [
 name = "loam-cli"
 version = "0.13.2"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "assert_fs",
  "cargo_metadata 0.18.1",

--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -39,6 +39,7 @@ clap = { version = "4.1.8", features = [
 cargo_metadata = { workspace = true }
 clap-cargo-extra = "0.3.0"
 
+anyhow = "1.0.86"
 thiserror = "1.0.31"
 serde = "1.0.82"
 serde_derive = "1.0.82"

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -454,7 +454,7 @@ export default new Client.Client({{
             });
 
             // After replace_all, check if there's an error message
-            if error_message != "" {
+            if !error_message.is_empty() {
                 return Err(Error::SubCommandExecutionFailure(
                     failed_subcommand,
                     error_message,

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/Cargo.lock
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-contract"
-version = "0.0.6"
+version = "0.0.0"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/custom_types/src/lib.rs
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/custom_types/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Symbol, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -8,13 +8,55 @@ pub struct State {
     pub last_incr: u32,
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub enum Asset {
+    Stellar(soroban_sdk::Address),
+    Other(soroban_sdk::Symbol),
+}
+
 const STATE: Symbol = symbol_short!("STATE");
+const TEST_CONFIG: Symbol = symbol_short!("TESTCFG");
+
+#[contracttype]
+pub struct TestConfig {
+    pub assets: Vec<Asset>,
+    pub base: Asset,
+    pub decimals: u32,
+    pub resolution: u32,
+}
 
 #[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
 impl IncrementContract {
+    /// test init
+    pub fn test_init(
+        env: Env,
+        assets: Vec<Asset>,
+        base: Asset,
+        decimals: u32,
+        resolution: u32,
+    ) {
+        if env.storage().instance().has(&TEST_CONFIG) {
+            panic!("test already initialized");
+        }
+
+        let config = TestConfig {
+            assets,
+            base,
+            decimals,
+            resolution,
+        };
+
+        env.storage().instance().set(&TEST_CONFIG, &config);
+    }
+
+    /// get test config
+    pub fn get_test_config(env: Env) -> TestConfig {
+        env.storage().instance().get(&TEST_CONFIG).unwrap()
+    }
     /// Increment increments an internal counter, and returns the value.
     pub fn increment(env: Env, incr: u32) -> u32 {
         // Get the current count.

--- a/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/Cargo.toml
+++ b/crates/loam-cli/tests/fixtures/soroban-init-boilerplate/contracts/token/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "soroban-token-contract"
 description = "Soroban standard token contract"
-version = "0.0.6"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]
@@ -13,17 +14,3 @@ soroban-token-sdk = { version = "20.3.1" }
 
 [dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true

--- a/crates/loam-cli/tests/it/build_clients/init_script.rs
+++ b/crates/loam-cli/tests/it/build_clients/init_script.rs
@@ -131,7 +131,8 @@ test_init --resolution 300000 --assets '[{"Stellar": "$(stellar contract id asse
         );
 
         // Check for successful initialization message
-        assert!(String::from_utf8_lossy(&output.stderr)
-            .contains("✅ Initialization script for \"soroban_custom_types_contract\" completed successfully"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains(
+            "✅ Initialization script for \"soroban_custom_types_contract\" completed successfully"
+        ));
     })
 }

--- a/crates/loam-cli/tests/it/build_clients/init_script.rs
+++ b/crates/loam-cli/tests/it/build_clients/init_script.rs
@@ -87,3 +87,51 @@ STELLAR_ACCOUNT=bob mint --amount 2000000 --to bob
         ));
     })
 }
+
+#[test]
+fn init_handles_quotations_and_subcommands_in_script() {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        env.set_environments_toml(
+            r#"
+development.accounts = [
+{ name = "me" },
+]
+
+[development.network]
+rpc-url = "http://localhost:8000/rpc"
+network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts]
+hello_world.client = false
+soroban_increment_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+
+[development.contracts.soroban_custom_types_contract]
+client = true
+init = """
+test_init --resolution 300000 --assets '[{"Stellar": "$(stellar contract id asset --asset native)"} ]' --decimals 14 --base '{"Stellar":"$(stellar contract id asset --asset native)"}'
+"""
+"#,
+        );
+
+        let output = env
+            .loam_env("development", true)
+            .output()
+            .expect("Failed to execute command");
+
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+        // Ensure the command executed successfully
+        assert!(output.status.success());
+
+        // Check for the presence of the initialization commands in the output
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(" -- test_init --resolution 300000")
+        );
+
+        // Check for successful initialization message
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("✅ Initialization script for \"soroban_custom_types_contract\" completed successfully"));
+    })
+}


### PR DESCRIPTION
Fixes https://github.com/loambuild/loam/issues/130

Adds subcommand support and uses `shlex` to parse the arguments so that it properly respects quoted string arguments.

### Limitations

This will not work if you escape quotes inside of quotes. The escaped characters get stripped out by the toml parsing. If you need double quotes in an argument you will need to use single quotes. Or you can escape the escape characters. 

To get the init script in the issue to work use this:
```
[development.contracts.data_feed]
client = true
init = """
admin_set --new-admin me
sep40_init --resolution 300000 --assets '[{"Stellar": "$(stellar contract id asset --asset native)"} ]' --decimals 14 --base '{"Stellar":"$(stellar contract id asset --asset native)"}'
"""
```

Another limitation is that I run the subcommands through `sh` if on linux and `cmd` if on windows. Perhaps we could add an argument to pass the preferred shell. Also, if the subcommand errors, program execution will stop and the error will be printed. 

