### PR TITLE
Fix/alias issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         STELLAR_CONTRACT_ID: core
     services:
       rpc:
-        image: stellar/quickstart:v423-testing
+        image: stellar/quickstart:v438-testing
         ports:
           - 8000:8000
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,7 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-cli"
-version = "21.3.0"
+version = "21.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3affc4ef5957c2e137255bc0b43c51d78e93a6b0d15fbc795bd136690e750d29"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -4095,6 +4097,7 @@ dependencies = [
  "futures",
  "futures-util",
  "gix",
+ "glob",
  "heck 0.5.0",
  "hex",
  "home",
@@ -4113,6 +4116,7 @@ dependencies = [
  "regex",
  "rpassword",
  "rust-embed",
+ "semver",
  "sep5",
  "serde",
  "serde-aux",
@@ -4283,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.2.0"
+version = "21.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b411868046bc9aad3d481ef57ec5db34c58016c715bf871d854c8c752872b19"
+checksum = "40917f326155433baf8d6fa36b3006c19139cf0acc01acf4eaf2516b3eaa23e3"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -4295,7 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-json"
-version = "21.3.0"
+version = "21.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13bb2611e28e3b4e6daf7caff90c2956fd842e97297fb308adeddc2f0fbb1ac"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4308,9 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.2.0"
+version = "21.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71e218a6ea10c0f858993d35b168a21ac7185c936c745a34a371d76d24fba0c"
+checksum = "f11343e04efdaf247f0cd9c8517cb093f60bd2490f8ee76c9f86e2c50308d443"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4324,7 +4330,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-tools"
-version = "21.3.0"
+version = "21.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1503c6e9e9deebefc6823ccd8f44b6714758ea2e4e5600ffc2520e5ccf7a8427"
 dependencies = [
  "base64 0.21.7",
  "ethnum",
@@ -4341,7 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "21.3.0"
+version = "21.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c34d8a1cd040ab4435160f7f4df845587e92c33fe2ea5c9d23f2af75df67521"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +369,12 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
+
+[[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "camino"
@@ -1088,12 +1107,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1101,6 +1136,17 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1137,6 +1183,7 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2141,6 +2188,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -3986,13 +4039,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-cli"
-version = "21.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f51b9832204b58200ace0e980ba63c435ea93952f03fbe1ada7a5c05a8a87f0"
+version = "21.3.0"
 dependencies = [
+ "async-compression",
  "async-trait",
  "base64 0.21.7",
  "bollard",
+ "bytesize",
  "cargo_metadata 0.18.1",
  "chrono",
  "clap",
@@ -4004,12 +4057,15 @@ dependencies = [
  "dotenvy",
  "ed25519-dalek",
  "ethnum",
+ "flate2",
+ "futures",
  "futures-util",
  "gix",
  "heck 0.5.0",
  "hex",
  "home",
  "http 0.2.12",
+ "humantime",
  "hyper 0.14.30",
  "hyper-tls",
  "itertools 0.10.5",
@@ -4048,6 +4104,7 @@ dependencies = [
  "termcolor_output",
  "thiserror",
  "tokio",
+ "tokio-util",
  "toml 0.5.11",
  "toml_edit 0.21.1",
  "tracing",
@@ -4204,9 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-json"
-version = "21.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc319732a8f4e13bb696895d40029b82a560c97c68948483654fec8e5881853"
+version = "21.3.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4235,9 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-tools"
-version = "21.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f84bb481640ddfe2d11b0878fe794f2fb5cdaf8f9044b7d07bb9108aee745a"
+version = "21.3.0"
 dependencies = [
  "base64 0.21.7",
  "ethnum",
@@ -4254,9 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "21.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69512e2e5ef2c1a0629c210040e63ad6e8fc509421e4754ba9744b541d838a04"
+version = "21.3.0"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -4677,6 +4728,7 @@ checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 
 [dependencies]
 loam-build = { path = "../loam-build", version = "0.7.3" }
-soroban-cli = "21.2.0"
+soroban-cli = { path = "/home/blaine/forks/stellar-cli/cmd/soroban-cli" }
 clap = { version = "4.1.8", features = [
     "derive",
     "env",

--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 
 [dependencies]
 loam-build = { path = "../loam-build", version = "0.7.3" }
-soroban-cli = { path = "/home/blaine/forks/stellar-cli/cmd/soroban-cli" }
+soroban-cli = "21.5.0"
 clap = { version = "4.1.8", features = [
     "derive",
     "env",

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -95,7 +95,7 @@ impl Args {
         Self::add_network_to_env(&current_env.network)?;
         // Create the '.stellar' directory if it doesn't exist - for saving contract aliases and account aliases
         std::fs::create_dir_all(workspace_root.join(".stellar"))
-            .map_err( soroban_cli::config::locator::Error::Io)?;
+            .map_err(soroban_cli::config::locator::Error::Io)?;
         Self::handle_accounts(current_env.accounts.as_deref()).await?;
         self.handle_contracts(
             workspace_root,

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -95,7 +95,7 @@ impl Args {
         Self::add_network_to_env(&current_env.network)?;
         // Create the '.stellar' directory if it doesn't exist - for saving contract aliases and account aliases
         std::fs::create_dir_all(workspace_root.join(".stellar"))
-            .map_err(|e| soroban_cli::config::locator::Error::Io(e))?;
+            .map_err( soroban_cli::config::locator::Error::Io)?;
         Self::handle_accounts(current_env.accounts.as_deref()).await?;
         self.handle_contracts(
             workspace_root,

--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -157,15 +157,16 @@ impl Args {
         }
     }
 
-    fn get_config_locator() -> cli::config::locator::Args {
+    fn get_config_locator(workspace_root: &std::path::Path) -> cli::config::locator::Args {
         cli::config::locator::Args {
             global: false,
-            config_dir: None,
+            config_dir: Some(workspace_root.to_path_buf()),
         }
     }
 
-    fn get_contract_alias(name: &str) -> Result<Option<String>, cli::config::locator::Error> {
-        let config_dir = Self::get_config_locator();
+    fn get_contract_alias(name: &str, workspace_root: &std::path::Path) -> Result<Option<String>, cli::config::locator::Error> {
+        let config_dir = Self::get_config_locator(workspace_root);
+        println!("config dir is {config_dir:#?}");
         let network_passphrase = std::env::var("STELLAR_NETWORK_PASSPHRASE")
             .expect("No STELLAR_NETWORK_PASSPHRASE environment variable set");
         config_dir.get_contract_id(name, &network_passphrase)
@@ -176,11 +177,12 @@ impl Args {
         contract_id: &str,
         hash: &str,
         network: &Network,
+        workspace_root: &std::path::Path,
     ) -> Result<bool, Error> {
         let result = cli::contract::fetch::Cmd {
             contract_id: contract_id.to_string(),
             out_file: None,
-            locator: Self::get_config_locator(),
+            locator: Self::get_config_locator(workspace_root),
             network: Self::get_network_args(network),
         }
         .run_against_rpc_server(None, None)
@@ -205,8 +207,9 @@ impl Args {
         name: &str,
         contract_id: &str,
         network: &Network,
+        workspace_root: &std::path::Path
     ) -> Result<(), cli::config::locator::Error> {
-        let config_dir = Self::get_config_locator();
+        let config_dir = Self::get_config_locator(workspace_root);
         let passphrase = network
             .network_passphrase
             .clone()
@@ -338,10 +341,10 @@ export default new Client.Client({{
             eprintln!("    ↳ hash: {hash}");
 
             // Check if we have an alias saved for this contract
-            let alias = Self::get_contract_alias(&name)?;
+            let alias = Self::get_contract_alias(&name, workspace_root)?;
             if let Some(contract_id) = alias {
                 match self
-                    .contract_hash_matches(&contract_id, &hash, network)
+                    .contract_hash_matches(&contract_id, &hash, network, workspace_root)
                     .await
                 {
                     Ok(true) => {
@@ -370,7 +373,7 @@ export default new Client.Client({{
             eprintln!("    ↳ contract_id: {contract_id}");
 
             // Save the alias for future use
-            Self::save_contract_alias(&name, &contract_id, network)?;
+            Self::save_contract_alias(&name, &contract_id, network, workspace_root)?;
 
             // Run init script if we're in development or test environment
             if self.loam_env(LoamEnv::Production) == "development"

--- a/crates/loam-cli/src/commands/init.rs
+++ b/crates/loam-cli/src/commands/init.rs
@@ -55,8 +55,9 @@ impl Cmd {
             project_path: self.project_path.to_string_lossy().to_string(),
             with_example: vec![],
             frontend_template: FRONTEND_TEMPLATE.to_string(),
+            overwrite: true,
         }
-        .run()?;
+        .run(&soroban_cli::commands::global::Args::default())?;
 
         // remove soroban hello_world default contract
         remove_dir_all(self.project_path.join("contracts/hello_world/")).map_err(|e| {

--- a/crates/loam-cli/tests/it/build_clients/accounts.rs
+++ b/crates/loam-cli/tests/it/build_clients/accounts.rs
@@ -22,8 +22,8 @@ soroban_token_contract.client = false
         let stderr = env.loam("build").assert().success().stderr_as_str();
         assert!(stderr.contains("creating keys for \"alice\""));
         assert!(stderr.contains("creating keys for \"bob\""));
-        assert!(env.cwd.join(".soroban/identity/alice.toml").exists());
-        assert!(env.cwd.join(".soroban/identity/bob.toml").exists());
+        assert!(env.cwd.join(".stellar/identity/alice.toml").exists());
+        assert!(env.cwd.join(".stellar/identity/bob.toml").exists());
 
         // check that they dont get overwritten if build is run again
         let stderr = env.loam("build").assert().success().stderr_as_str();
@@ -44,6 +44,6 @@ soroban_token_contract.client = false
             .assert()
             .success()
             .stderr_as_str();
-        assert!(stderr.contains("Account already exists"));
+        assert!(stderr.is_empty());
     });
 }

--- a/crates/loam-cli/tests/it/util.rs
+++ b/crates/loam-cli/tests/it/util.rs
@@ -223,4 +223,17 @@ impl TestEnv {
     pub fn set_environments_toml(&self, contents: impl AsRef<[u8]>) {
         std::fs::write(self.cwd.join("environments.toml"), contents).unwrap();
     }
+
+    pub fn switch_to_new_directory(
+        &mut self,
+        template: &str,
+        new_dir_name: &str,
+    ) -> std::io::Result<()> {
+        let new_dir = self.temp_dir.path().join(new_dir_name);
+        fs::create_dir_all(&new_dir)?;
+        let template_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+        copy(template_dir.join(template), &new_dir, &CopyOptions::new()).unwrap();
+        self.cwd = new_dir.join(template);
+        Ok(())
+    }
 }

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ build:
 
 # Setup the project to use a pinned version of the CLI
 setup:
-    -cargo binstall -y --install-path ./target/bin soroban-cli --version 21.0.0
+    -cargo binstall -y --install-path ./target/bin soroban-cli --version 21.5.0
 
 # Build loam-cli test contracts to speed up testing
 build-cli-test-contracts:


### PR DESCRIPTION
fixes https://github.com/loambuild/loam/issues/145
Also Upgrades to stellar-cli 21.5
The fix is done by creating the `.stellar` directory in the `workspace_root`. This is needed because if that directory doesn't exist within the directory passed to `locator::Args` via `config_dir` it will ignore `config_dir` and fall back to searching up the tree of directories until it finds a `.stellar` directory that already exists. 