### PR TITLE
fix(cli): Client init: don't specify publicKey

### DIFF
--- a/crates/loam-cli/src/commands/build/clients.rs
+++ b/crates/loam-cli/src/commands/build/clients.rs
@@ -245,7 +245,6 @@ export default new Client.Client({{
   networkPassphrase: '{network}',
   contractId: '{contract_id}',
   rpcUrl,{allow_http}
-  publicKey: undefined,
 }});
 "#
         );


### PR DESCRIPTION
The typings encourage you to omit the parameter altogether, rather than
explicitly setting it to `undefined`.