### PR TITLE
fix: update soroban-sdk to v22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         STELLAR_CONTRACT_ID: core
     services:
       rpc:
-        image: stellar/quickstart:v438-testing
+        image: stellar/quickstart:testing
         ports:
           - 8000:8000
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,15 +1902,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -2116,7 +2107,7 @@ dependencies = [
  "shlex",
  "soroban-cli",
  "stellar-strkey 0.0.11",
- "stellar-xdr 22.0.0-rc.1.1",
+ "stellar-xdr",
  "strsim",
  "symlink",
  "thiserror",
@@ -2134,7 +2125,7 @@ version = "0.6.15"
 dependencies = [
  "loam-sdk-macro",
  "loam-soroban-sdk",
- "soroban-sdk 21.7.7",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -2152,7 +2143,7 @@ dependencies = [
  "regex",
  "sha2 0.10.8",
  "stellar-strkey 0.0.11",
- "stellar-xdr 22.0.0-rc.1.1",
+ "stellar-xdr",
  "syn 2.0.39",
  "syn-file-expand",
  "thiserror",
@@ -2163,7 +2154,7 @@ name = "loam-soroban-sdk"
 version = "0.6.15"
 dependencies = [
  "loam-sdk-macro",
- "soroban-sdk 21.7.7",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -3423,18 +3414,6 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "soroban-builtin-sdk-macros"
 version = "22.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c45d2492cd44f05cc79eeb857985f153f12a4423ce51b4b746b5925024c473b1"
@@ -3447,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-cli"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e31c03e59f36c33182481bfe90bb9b0972ed439381eb47e351a2c4d39b3154c"
+checksum = "edcd83341170215c2199446aec1917519481b48df3dab2bd13037d50f99c8296"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -3495,16 +3474,16 @@ dependencies = [
  "sha2 0.10.8",
  "shell-escape",
  "shlex",
- "soroban-ledger-snapshot 22.0.0-rc.3",
- "soroban-sdk 22.0.0-rc.3",
- "soroban-spec 22.0.0-rc.3",
+ "soroban-ledger-snapshot",
+ "soroban-sdk",
+ "soroban-spec",
  "soroban-spec-json",
- "soroban-spec-rust 22.0.0-rc.3",
+ "soroban-spec-rust",
  "soroban-spec-tools",
  "soroban-spec-typescript",
  "stellar-rpc-client",
  "stellar-strkey 0.0.11",
- "stellar-xdr 22.0.0-rc.1.1",
+ "stellar-xdr",
  "strsim",
  "strum",
  "strum_macros",
@@ -3528,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.2.1"
+version = "22.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1c89463835fe6da996318156d39f424b4f167c725ec692e5a7a2d4e694b3d"
+checksum = "39b6d2ec8955243394278e1fae88be3b367fcfed9cf74e5044799a90786a8642"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -3538,39 +3517,11 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "soroban-env-macros 21.2.1",
+ "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 21.2.0",
+ "stellar-xdr",
  "wasmparser",
-]
-
-[[package]]
-name = "soroban-env-common"
-version = "22.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b6d2ec8955243394278e1fae88be3b367fcfed9cf74e5044799a90786a8642"
-dependencies = [
- "crate-git-revision",
- "ethnum",
- "num-derive",
- "num-traits",
- "serde",
- "soroban-env-macros 22.0.0-rc.3",
- "soroban-wasmi",
- "static_assertions",
- "stellar-xdr 22.0.0-rc.1.1",
- "wasmparser",
-]
-
-[[package]]
-name = "soroban-env-guest"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
-dependencies = [
- "soroban-env-common 21.2.1",
- "static_assertions",
 ]
 
 [[package]]
@@ -3579,41 +3530,8 @@ version = "22.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4002fc582cd20cc9b9fbb73959bc5d6b5b15feda11485cbfab0c28e78ecbab3e"
 dependencies = [
- "soroban-env-common 22.0.0-rc.3",
+ "soroban-env-common",
  "static_assertions",
-]
-
-[[package]]
-name = "soroban-env-host"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
-dependencies = [
- "backtrace",
- "curve25519-dalek",
- "ecdsa",
- "ed25519-dalek",
- "elliptic-curve",
- "generic-array",
- "getrandom",
- "hex-literal",
- "hmac 0.12.1",
- "k256",
- "num-derive",
- "num-integer",
- "num-traits",
- "p256",
- "rand",
- "rand_chacha",
- "sec1",
- "sha2 0.10.8",
- "sha3",
- "soroban-builtin-sdk-macros 21.2.1",
- "soroban-env-common 21.2.1",
- "soroban-wasmi",
- "static_assertions",
- "stellar-strkey 0.0.8",
- "wasmparser",
 ]
 
 [[package]]
@@ -3644,27 +3562,12 @@ dependencies = [
  "sec1",
  "sha2 0.10.8",
  "sha3",
- "soroban-builtin-sdk-macros 22.0.0-rc.3",
- "soroban-env-common 22.0.0-rc.3",
+ "soroban-builtin-sdk-macros",
+ "soroban-env-common",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.9",
  "wasmparser",
-]
-
-[[package]]
-name = "soroban-env-macros"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "stellar-xdr 21.2.0",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -3678,22 +3581,8 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 22.0.0-rc.1.1",
+ "stellar-xdr",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "soroban-ledger-snapshot"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6edf92749fd8399b417192d301c11f710b9cdce15789a3d157785ea971576fa"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "soroban-env-common 21.2.1",
- "soroban-env-host 21.2.1",
- "thiserror",
 ]
 
 [[package]]
@@ -3705,31 +3594,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common 22.0.0-rc.3",
- "soroban-env-host 22.0.0-rc.3",
+ "soroban-env-common",
+ "soroban-env-host",
  "thiserror",
-]
-
-[[package]]
-name = "soroban-sdk"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcdf04484af7cc731a7a48ad1d9f5f940370edeea84734434ceaf398a6b862e"
-dependencies = [
- "arbitrary",
- "bytes-lit",
- "ctor",
- "derive_arbitrary",
- "ed25519-dalek",
- "rand",
- "rustc_version",
- "serde",
- "serde_json",
- "soroban-env-guest 21.2.1",
- "soroban-env-host 21.2.1",
- "soroban-ledger-snapshot 21.7.7",
- "soroban-sdk-macros 21.7.7",
- "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -3738,36 +3605,19 @@ version = "22.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d063d0df000aaec20105aab3d743660322bc0269934ea95d79fa19aa8792385"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
+ "ctor",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
  "serde_json",
- "soroban-env-guest 22.0.0-rc.3",
- "soroban-env-host 22.0.0-rc.3",
- "soroban-ledger-snapshot 22.0.0-rc.3",
- "soroban-sdk-macros 22.0.0-rc.3",
+ "soroban-env-guest",
+ "soroban-env-host",
+ "soroban-ledger-snapshot",
+ "soroban-sdk-macros",
  "stellar-strkey 0.0.9",
-]
-
-[[package]]
-name = "soroban-sdk-macros"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0974e413731aeff2443f2305b344578b3f1ffd18335a7ba0f0b5d2eb4e94c9ce"
-dependencies = [
- "crate-git-revision",
- "darling",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "sha2 0.10.8",
- "soroban-env-common 21.2.1",
- "soroban-spec 21.7.7",
- "soroban-spec-rust 21.7.7",
- "stellar-xdr 21.2.0",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -3783,23 +3633,11 @@ dependencies = [
  "quote",
  "rustc_version",
  "sha2 0.10.8",
- "soroban-env-common 22.0.0-rc.3",
- "soroban-spec 22.0.0-rc.3",
- "soroban-spec-rust 22.0.0-rc.3",
- "stellar-xdr 22.0.0-rc.1.1",
+ "soroban-env-common",
+ "soroban-spec",
+ "soroban-spec-rust",
+ "stellar-xdr",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "soroban-spec"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c70b20e68cae3ef700b8fa3ae29db1c6a294b311fba66918f90cb8f9fd0a1a"
-dependencies = [
- "base64 0.13.1",
- "stellar-xdr 21.2.0",
- "thiserror",
- "wasmparser",
 ]
 
 [[package]]
@@ -3809,39 +3647,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69001c97783ed3ce197eac2404e7beeabedd16e40e6f0aa210d1bc6a13063c33"
 dependencies = [
  "base64 0.13.1",
- "stellar-xdr 22.0.0-rc.1.1",
+ "stellar-xdr",
  "thiserror",
  "wasmparser",
 ]
 
 [[package]]
 name = "soroban-spec-json"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20bf95b0d734c6498c2bf26667bc508ff24cbf6ae450307a07ef62668fac1d"
+checksum = "665e1990e8d92cabe3eecbc79d2b52a6ccfda189fb654273f7921df8c0333992"
 dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 22.0.0-rc.3",
- "stellar-xdr 22.0.0-rc.1.1",
- "thiserror",
-]
-
-[[package]]
-name = "soroban-spec-rust"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dafbde981b141b191c6c036abc86097070ddd6eaaa33b273701449501e43d3"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "soroban-spec 21.7.7",
- "stellar-xdr 21.2.0",
- "syn 2.0.39",
+ "soroban-spec",
+ "stellar-xdr",
  "thiserror",
 ]
 
@@ -3855,35 +3677,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "soroban-spec 22.0.0-rc.3",
- "stellar-xdr 22.0.0-rc.1.1",
+ "soroban-spec",
+ "stellar-xdr",
  "syn 2.0.39",
  "thiserror",
 ]
 
 [[package]]
 name = "soroban-spec-tools"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e144710a84b0a1892a8a3ba2f662f4ab9cdcf3a6b92147ad75f3521d3a9e81"
+checksum = "b478b78b95fb1c4b615fa8684ff493802787f63a429ada45dedb1f728a6a8207"
 dependencies = [
  "base64 0.21.7",
  "ethnum",
  "hex",
  "itertools 0.10.5",
  "serde_json",
- "soroban-spec 22.0.0-rc.3",
+ "soroban-spec",
  "stellar-strkey 0.0.11",
- "stellar-xdr 22.0.0-rc.1.1",
+ "stellar-xdr",
  "thiserror",
  "wasmparser",
 ]
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c5a6651a6a2065427312358156c58860614ca832d1a0b8efdb2280ff1eddf2"
+checksum = "714848b456f1ffde42008a98e74fa56b7aeef98658a28927736e5b5b25039dc3"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -3894,8 +3716,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 22.0.0-rc.3",
- "stellar-xdr 22.0.0-rc.1.1",
+ "soroban-spec",
+ "stellar-xdr",
  "thiserror",
 ]
 
@@ -3952,7 +3774,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "stellar-strkey 0.0.9",
- "stellar-xdr 22.0.0-rc.1.1",
+ "stellar-xdr",
  "termcolor",
  "termcolor_output",
  "thiserror",
@@ -3994,26 +3816,11 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "21.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2675a71212ed39a806e415b0dbf4702879ff288ec7f5ee996dda42a135512b50"
-dependencies = [
- "arbitrary",
- "base64 0.13.1",
- "crate-git-revision",
- "escape-bytes",
- "hex",
- "serde",
- "serde_with",
- "stellar-strkey 0.0.8",
-]
-
-[[package]]
-name = "stellar-xdr"
 version = "22.0.0-rc.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c88dc0e928b9cb65ea43836b52560bb4ead3e32895f5019ca223dc7cd1966cbf"
 dependencies = [
+ "arbitrary",
  "base64 0.13.1",
  "clap",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ loam-soroban-sdk = { path = "./crates/loam-soroban-sdk" }
 loam-sdk-macro = { path = "./crates/loam-sdk-macro" }
 loam-subcontract-ft = { path = "./crates/loam-subcontract-ft" }
 
-soroban-sdk = "21.7.2"
+soroban-sdk = "22.0.0-rc.3"
 stellar-xdr = "22.0.0-rc.1.1"
 stellar-strkey = "0.0.11"
 

--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 
 [dependencies]
 loam-build = { path = "../loam-build", version = "0.7.3" }
-soroban-cli = "22.0.0"
+soroban-cli = "22.0.1"
 clap = { version = "4.1.8", features = [
     "derive",
     "env",

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ build:
 
 # Setup the project to use a pinned version of the CLI
 setup:
-    -cargo binstall -y --install-path ./target/bin stellar-cli --version 22.0.0
+    -cargo binstall -y --install-path ./target/bin stellar-cli --version 22.0.1
 
 # Build loam-cli test contracts to speed up testing
 build-cli-test-contracts:


### PR DESCRIPTION
Upgrades `soroban-sdk` to v22 to match the  `soroban-cli` version. Fixes an issue where the mismatch caused a error resolving the `testutil` crate: `error[E0433]: failed to resolve: could not find `testutils` in the crate root`

It also updates the github tests to use the same version of the docker quickstart image as is used in `stellar-cli`. 